### PR TITLE
Add support for multiple keys in database

### DIFF
--- a/backend/src/booking_routes.rs
+++ b/backend/src/booking_routes.rs
@@ -1,31 +1,40 @@
-use crate::database::DataBase;
-use common::Booking;
+use crate::database::{DataBase, Storage};
 use warp::Filter;
 
-pub fn routes(
-    db: DataBase<Vec<Booking>>,
-) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+pub const BOOKINGS_KEY: &str = "bookings";
+
+pub fn routes<StorageType>(
+    db: DataBase<StorageType>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+where
+    StorageType: Storage,
+{
     filters::get_bookings(db.clone()).or(filters::add_booking(db.clone()))
 }
 
 mod filters {
     use super::handlers;
-    use crate::database::DataBase;
-    use common::Booking;
+    use crate::database::{DataBase, Storage};
     use warp::{Filter, Rejection, Reply};
 
-    pub fn get_bookings(
-        db: DataBase<Vec<Booking>>,
-    ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    pub fn get_bookings<StorageType>(
+        db: DataBase<StorageType>,
+    ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone
+    where
+        StorageType: Storage,
+    {
         warp::path!("api" / "bookings")
             .and(warp::get())
             .and(with_database(db))
             .and_then(handlers::get_bookings)
     }
 
-    pub fn add_booking(
-        db: DataBase<Vec<Booking>>,
-    ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    pub fn add_booking<StorageType>(
+        db: DataBase<StorageType>,
+    ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone
+    where
+        StorageType: Storage,
+    {
         warp::path!("api" / "booking")
             .and(warp::post())
             .and(warp::body::json())
@@ -33,28 +42,43 @@ mod filters {
             .then(handlers::add_booking)
     }
 
-    fn with_database(
-        db: DataBase<Vec<Booking>>,
-    ) -> impl Filter<Extract = (DataBase<Vec<Booking>>,), Error = std::convert::Infallible> + Clone
+    fn with_database<StorageType>(
+        db: DataBase<StorageType>,
+    ) -> impl Filter<Extract = (DataBase<StorageType>,), Error = std::convert::Infallible> + Clone
+    where
+        StorageType: Storage,
     {
         warp::any().map(move || db.clone())
     }
 }
 
 mod handlers {
-    use crate::database::DataBase;
+    use crate::database::{DataBase, Storage};
     use common::Booking;
     use warp::{Rejection, Reply};
 
-    pub async fn get_bookings(db: DataBase<Vec<Booking>>) -> Result<impl Reply, Rejection> {
-        let bookings = db.get_data().await;
-        Ok(warp::reply::json(&*bookings))
+    use super::BOOKINGS_KEY;
+
+    pub async fn get_bookings<StorageType>(
+        db: DataBase<StorageType>,
+    ) -> Result<impl Reply, Rejection>
+    where
+        StorageType: Storage,
+    {
+        let bookings = db
+            .get_data::<Vec<Booking>>(BOOKINGS_KEY)
+            .await
+            .expect("As long as no one is manually editing the database, this should never fail.");
+        Ok(warp::reply::json(&bookings))
     }
 
-    pub async fn add_booking(booking: Booking, mut db: DataBase<Vec<Booking>>) -> impl Reply {
-        match db.update_data(|mut v| v.push(booking)).await {
+    pub async fn add_booking<StorageType>(booking: Booking, db: DataBase<StorageType>) -> impl Reply
+    where
+        StorageType: Storage,
+    {
+        match db.update_data::<Vec<Booking>, _>(BOOKINGS_KEY, |mut v| { v.push(booking); v }).await {
             Ok(_) => warp::reply::with_status(
-                db.get_data().await.len().to_string(),
+                db.get_data::<Vec<Booking>>(BOOKINGS_KEY).await.expect("As long as no one is manually editing the database, this should never fail.").len().to_string(),
                 warp::http::StatusCode::CREATED,
             ),
             Err(_) => warp::reply::with_status(
@@ -62,5 +86,66 @@ mod handlers {
                 warp::http::StatusCode::SERVICE_UNAVAILABLE,
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::database::create_in_memory_database;
+
+    use super::*;
+    use common::Booking;
+
+    #[tokio::test]
+    async fn test_get_bookings() {
+        let db = create_in_memory_database();
+        let booking = Booking {
+            telescope_name: "test-telescope".to_string(),
+            user_name: "test-user".to_string(),
+            start_time: chrono::Utc::now(),
+            end_time: chrono::Utc::now(),
+        };
+        db.update_data::<Vec<Booking>, _>(BOOKINGS_KEY, |mut bookings| {
+            bookings.push(booking.clone());
+            bookings
+        })
+        .await
+        .expect("should be possible to set db data");
+        let response = warp::test::request()
+            .method("GET")
+            .path("/api/bookings")
+            .reply(&routes(db))
+            .await;
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response.body(),
+            serde_json::to_string(&[booking]).unwrap().as_bytes()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_booking() {
+        let db = create_in_memory_database();
+        let booking = Booking {
+            telescope_name: "test-telescope".to_string(),
+            user_name: "test-user".to_string(),
+            start_time: chrono::Utc::now(),
+            end_time: chrono::Utc::now(),
+        };
+        let response = warp::test::request()
+            .method("POST")
+            .path("/api/booking")
+            .json(&booking)
+            .reply(&routes(db.clone()))
+            .await;
+        assert_eq!(response.status(), warp::http::StatusCode::CREATED);
+        assert_eq!(response.body(), "1"); // 1 because the database is empty before the request
+
+        assert_eq!(
+            vec![booking],
+            db.get_data::<Vec<Booking>>(BOOKINGS_KEY).await.expect(
+                "As long as no one is manually editing the database, this should never fail."
+            )
+        );
     }
 }

--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -149,13 +149,13 @@ where
     ///
     /// # Examples
     ///
-    /// ```
-    /// use backend::database::DataBase;
+    /// ```rust
+    /// use backend::database::{DataBase, create_in_memory_database};
     ///
-    /// let db = DataBase::create_in_memory();
-    /// let data = db.set_data::<Vec<i32>("numbers", vec![42]).await;
-    /// let data = db.get_data::<Vec<i32>("numbers").await;
-    /// assert_eq!(data, vec![42])
+    /// let db = create_in_memory_database();
+    /// db.update_data::<Vec<i32>>("numbers", |mut v| v.push(42)).await.unwrap();
+    /// let data = db.get_data::<Vec<i32>("numbers").await.unwrap();
+    /// assert_eq!(data, vec![42]);
     /// ```
     pub async fn get_data<T>(&self, key: &'static str) -> Result<T, DataBaseError>
     where
@@ -179,12 +179,13 @@ where
     ///
     /// # Examples
     ///
-    /// ```
-    /// use backend::database::DataBase;
+    /// ```rust
+    /// use backend::database::{DataBase, create_in_memory_database};
     ///
     /// let db = create_in_memory_database();
     /// db.update_data::<Vec<i32>>("numbers", |mut v| v.push(42)).await.unwrap();
-    /// assert_eq!(db.get_data::<Vec<i32>>("numbers").await, vec![42])
+    /// let data = db.get_data::<Vec<i32>>("numbers").await.unwrap();
+    /// assert_eq!(data, vec![42]);
     /// ```
     pub async fn update_data<T, F>(&self, key: &'static str, f: F) -> Result<(), DataBaseError>
     where

--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -219,4 +219,22 @@ mod test {
             .expect("should be able to get db data");
         assert_eq!(data, vec![42])
     }
+
+    #[tokio::test]
+    async fn test_update_multiple_times() {
+        let db = create_in_memory_database();
+        for i in 0..10 {
+            db.update_data::<Vec<i32>, _>("numbers", |mut v| {
+                v.push(i);
+                v
+            })
+            .await
+            .expect("should be able to update db data");
+        }
+        let data = db
+            .get_data::<Vec<i32>>("numbers")
+            .await
+            .expect("should be able to get db data");
+        assert_eq!(data, (0..10).collect::<Vec<i32>>())
+    }
 }

--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -59,21 +59,14 @@ impl FileStorage {
 
 #[async_trait]
 impl Storage for FileStorage {
-    async fn read(
-        &self,
-        key: &str,
-    ) -> Result<Option<Vec<u8>>, DataBaseError> {
+    async fn read(&self, key: &str) -> Result<Option<Vec<u8>>, DataBaseError> {
         let mut file = fs::File::open(self.get_path(key)).await?;
         let mut data = Vec::new();
         file.read_to_end(&mut data).await?;
         Ok(Some(data))
     }
 
-    async fn write(
-        &mut self,
-        key: &str,
-         data: &[u8]
-        ) -> Result<(), DataBaseError> {
+    async fn write(&mut self, key: &str, data: &[u8]) -> Result<(), DataBaseError> {
         let mut file = fs::File::create(self.get_path(key)).await?;
         file.write_all(data).await?;
         Ok(())
@@ -93,7 +86,9 @@ where
 /// Changes to the data in the returned database are never written to any
 /// file.
 pub fn create_in_memory_database() -> DataBase<InMemoryStorage> {
-    let store = InMemoryStorage { data: HashMap::new() };
+    let store = InMemoryStorage {
+        data: HashMap::new(),
+    };
     DataBase::<InMemoryStorage> {
         storage: Arc::new(RwLock::new(store)),
     }
@@ -141,9 +136,7 @@ where
     {
         let storage = self.storage.read().await;
         match storage.read(key).await? {
-            Some(data) => {
-                Ok(serde_json::from_slice(&data)?)
-            }
+            Some(data) => Ok(serde_json::from_slice(&data)?),
             None => Ok(T::default()),
         }
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,6 @@
-use crate::database::DataBase;
+use crate::database::create_database_from_directory;
 use crate::telescope::{create_telescope_collection, TELESCOPE_UPDATE_INTERVAL};
 use clap::Parser;
-use common::Booking;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -83,9 +82,7 @@ async fn main() {
     };
     log::info!("Started {} telescope services", telescope_services.len());
 
-    let database = DataBase::<Vec<Booking>>::from_file("database.json")
-        .await
-        .unwrap();
+    let database = create_database_from_directory("database").await.unwrap();
 
     let weather_routes = warp::path!("api" / "weather").map(weather::get_weather_info);
 


### PR DESCRIPTION
I added support for multiple keys in the "database". I am planning to move the telescope configurations into the "database". Does this change make sense with your design? Or does it break some intended use case?

I know I killed the cache. Sorry! It got tricky to get right and the performance impact should be relatively small. It should be possible to make a CachedFileStorage but that will result in multiple layers of locks.