### PR TITLE
Extract TelescopeController from SalsaTelescope

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,6 +14,7 @@ mod salsa_telescope;
 mod telescope;
 mod telescope_controller;
 mod telescope_routes;
+mod telescope_tracker;
 mod weather;
 
 #[derive(Parser, Debug)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -12,6 +12,7 @@ mod fake_telescope;
 mod frontend_routes;
 mod salsa_telescope;
 mod telescope;
+mod telescope_controller;
 mod telescope_routes;
 mod weather;
 

--- a/backend/src/salsa_telescope.rs
+++ b/backend/src/salsa_telescope.rs
@@ -1,5 +1,5 @@
 use crate::telescope::Telescope;
-use crate::telescope_controller::TelescopeController;
+use crate::telescope_tracker::TelescopeTracker;
 use async_trait::async_trait;
 use chrono::Utc;
 use common::{
@@ -23,7 +23,7 @@ pub struct ActiveIntegration {
 pub struct SalsaTelescope {
     name: String,
     receiver_address: String,
-    controller: TelescopeController,
+    controller: TelescopeTracker,
     receiver_configuration: ReceiverConfiguration,
     measurements: Arc<Mutex<Vec<Measurement>>>,
     active_integration: Option<ActiveIntegration>,
@@ -37,7 +37,7 @@ pub fn create(
     SalsaTelescope {
         name,
         receiver_address,
-        controller: TelescopeController::new(controller_address),
+        controller: TelescopeTracker::new(controller_address),
         receiver_configuration: ReceiverConfiguration { integrate: false },
         measurements: Arc::new(Mutex::new(Vec::new())),
         active_integration: None,
@@ -256,7 +256,7 @@ async fn measure(
 #[async_trait]
 impl Telescope for SalsaTelescope {
     async fn get_direction(&self) -> Result<Direction, TelescopeError> {
-        self.controller.direction().await
+        self.controller.direction()
     }
 
     async fn get_target(&self) -> Result<TelescopeTarget, TelescopeError> {
@@ -267,7 +267,7 @@ impl Telescope for SalsaTelescope {
         &mut self,
         target: TelescopeTarget,
     ) -> Result<TelescopeTarget, TelescopeError> {
-        self.controller.set_target(target).await
+        self.controller.set_target(target)
     }
 
     async fn set_receiver_configuration(
@@ -357,23 +357,10 @@ impl Telescope for SalsaTelescope {
 #[cfg(test)]
 mod test {
     use chrono::TimeZone;
+    use hex_literal::hex;
 
     use super::*;
     use std::f64::consts::PI;
-
-    #[test]
-    fn test_rot2prog_angle_to_bytes() {
-        assert_eq!(
-            rot2prog_angle_to_bytes(0.0),
-            hex!("3336303030"),
-            "0.0 should be 0x3336303030 (telescope expects angle + 360)"
-        );
-        assert_eq!(
-            rot2prog_angle_to_bytes(5.54_f64.to_radians()),
-            hex!("3336353534"),
-            "5.54 should be 0x3336353534 (example from documentation)"
-        );
-    }
 
     #[test]
     fn test_rot2prog_bytes_to_angle_documented() {
@@ -385,252 +372,6 @@ mod test {
             (rot2prog_bytes_to_angle_documented(&hex!("3338323333")) - 22.33_f64.to_radians())
                 .abs()
                 < 0.01,
-        );
-    }
-
-    #[test]
-    fn test_rot2prog_bytes_to_angle() {
-        assert!((rot2prog_bytes_to_angle(&hex!("0306000000")) - 0.0).abs() < 0.01,);
-    }
-
-    impl TelescopeCommand {
-        fn from_bytes(bytes: &[u8]) -> TelescopeCommand {
-            assert!(bytes.len() == 13);
-            if bytes[0] != 0x57 {
-                panic!("All commands should start with 0x57");
-            } else if bytes[bytes.len() - 1] != 0x20 {
-                panic!("All commands should end with 0x20");
-            }
-
-            match bytes[bytes.len() - 2] {
-                0x0F => TelescopeCommand::Stop,
-                0xEE => TelescopeCommand::Restart,
-                0x6F => TelescopeCommand::GetDirection,
-                0x5F => TelescopeCommand::SetDirection(Direction {
-                    azimuth: rot2prog_bytes_to_angle_documented(&bytes[1..=5]),
-                    altitude: rot2prog_bytes_to_angle_documented(&bytes[6..=10]),
-                }),
-                command_identifier => {
-                    panic!("Unknown command identifier: {:x}", command_identifier)
-                }
-            }
-        }
-    }
-
-    // Responses are documented as ascii encoded numbers, but the telescope seems to return the bytes directly.
-    fn rot2prog_response_angle_to_bytes(angle: f64) -> [u8; 5] {
-        let mut bytes = [0; 5];
-        let angle = ((angle.to_degrees() + 360.0) * 100.0).round();
-        bytes[0] = (angle / 10000.0) as u8;
-        bytes[1] = ((angle % 10000.0) / 1000.0) as u8;
-        bytes[2] = ((angle % 1000.0) / 100.0) as u8;
-        bytes[3] = ((angle % 100.0) / 10.0) as u8;
-        bytes[4] = (angle % 10.0) as u8;
-        bytes
-    }
-
-    impl TelescopeResponse {
-        fn to_bytes(&self) -> Vec<u8> {
-            match self {
-                TelescopeResponse::Ack => hex!("570000000000000000000020").to_vec(),
-                TelescopeResponse::CurrentDirection(direction) => {
-                    let mut bytes = Vec::with_capacity(13);
-                    bytes.extend(hex!("58"));
-                    bytes.extend(rot2prog_response_angle_to_bytes(direction.azimuth).as_slice());
-                    bytes.extend(rot2prog_response_angle_to_bytes(direction.altitude).as_slice());
-                    bytes.extend(hex!("20"));
-                    bytes
-                }
-            }
-        }
-    }
-
-    // This is a fake connection that can be used to test the telescope without a real connection
-    // It is set up with the response that the telescope should send and will store all writes
-    struct FakeTelescopeConnection {
-        horizontal: Direction,
-        commands: Vec<TelescopeCommand>,
-    }
-
-    impl Write for FakeTelescopeConnection {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            let command = TelescopeCommand::from_bytes(buf);
-            self.commands.push(command);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl Read for FakeTelescopeConnection {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            let response = match self.commands.last().expect("No commands sent to telescope") {
-                TelescopeCommand::Stop => TelescopeResponse::Ack,
-                TelescopeCommand::Restart => TelescopeResponse::Ack,
-                TelescopeCommand::GetDirection => {
-                    TelescopeResponse::CurrentDirection(self.horizontal)
-                }
-                TelescopeCommand::SetDirection(_) => {
-                    TelescopeResponse::CurrentDirection(self.horizontal)
-                }
-            }
-            .to_bytes();
-
-            buf[..response.len()].copy_from_slice(&response);
-            Ok(response.len())
-        }
-    }
-
-    #[test]
-    fn test_set_command() {
-        let mut stream = FakeTelescopeConnection {
-            horizontal: Direction {
-                azimuth: 0.0,
-                altitude: PI / 2.0,
-            },
-            commands: Vec::new(),
-        };
-
-        let response = send_command(
-            &mut stream,
-            TelescopeCommand::SetDirection(Direction {
-                azimuth: PI,
-                altitude: PI / 4.0,
-            }),
-        );
-        assert_eq!(
-            stream.commands,
-            [TelescopeCommand::SetDirection(Direction {
-                azimuth: PI,
-                altitude: PI / 4.0,
-            })]
-        );
-
-        let response = match response {
-            Ok(response) => response,
-            Err(e) => panic!("Error sending command: {}", e),
-        };
-        assert_eq!(
-            response,
-            TelescopeResponse::CurrentDirection(Direction {
-                azimuth: 0.0,
-                altitude: PI / 2.0,
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn test_update_direction() {
-        let mut telescope = create(
-            "salsa".to_string(),
-            "127.0.0.1:3000".to_string(),
-            "127.0.0.2".to_string(),
-        );
-
-        let mut stream = FakeTelescopeConnection {
-            horizontal: Direction {
-                azimuth: 0.0,
-                altitude: PI / 2.0,
-            },
-            commands: Vec::new(),
-        };
-
-        // Send an initial stop command to set the current direction
-        telescope
-            .update_direction(Utc::now(), &mut stream)
-            .await
-            .unwrap();
-        assert_eq!(
-            stream.commands,
-            [TelescopeCommand::GetDirection, TelescopeCommand::Stop]
-        );
-        assert_eq!(telescope.commanded_horizontal, None);
-        assert_eq!(
-            TelescopeStatus::Idle,
-            telescope.get_info().await.unwrap().status
-        );
-
-        // Inject the time to ensure that the target is not below horizon
-        let when = Utc.with_ymd_and_hms(2023, 4, 7, 12, 0, 0).unwrap();
-        stream.commands.clear();
-        telescope.target = TelescopeTarget::Galactic {
-            l: PI / 2.0,
-            b: 0.0,
-        };
-        telescope.update_direction(when, &mut stream).await.unwrap();
-        assert_eq!(2, stream.commands.len());
-        assert_eq!(stream.commands[0], TelescopeCommand::GetDirection);
-        assert!(matches!(
-            stream.commands[1],
-            TelescopeCommand::SetDirection { .. }
-        ));
-        assert!(telescope.commanded_horizontal.is_some());
-        assert_eq!(
-            TelescopeStatus::Slewing,
-            telescope.get_info().await.unwrap().status
-        );
-
-        // Calling update_direction when telescope is on target does not send set direction command
-        stream.horizontal = telescope.commanded_horizontal.unwrap();
-        stream.commands.clear();
-        telescope.update_direction(when, &mut stream).await.unwrap();
-        assert_eq!(stream.commands, [TelescopeCommand::GetDirection]);
-        assert_eq!(
-            TelescopeStatus::Tracking,
-            telescope.get_info().await.unwrap().status
-        );
-
-        // Stopping telescope send stop command
-        stream.commands.clear();
-        telescope.target = TelescopeTarget::Stopped;
-        telescope
-            .update_direction(Utc::now(), &mut stream)
-            .await
-            .unwrap();
-        assert_eq!(
-            stream.commands,
-            [TelescopeCommand::GetDirection, TelescopeCommand::Stop]
-        );
-        assert_eq!(telescope.commanded_horizontal, None);
-        assert_eq!(
-            TelescopeStatus::Idle,
-            telescope.get_info().await.unwrap().status
-        );
-
-        // Calling update_direction again does not send set direction command
-        stream.commands.clear();
-        telescope
-            .update_direction(Utc::now(), &mut stream)
-            .await
-            .unwrap();
-        assert_eq!(stream.commands, [TelescopeCommand::GetDirection]);
-        assert_eq!(telescope.commanded_horizontal, None);
-        assert_eq!(
-            TelescopeStatus::Idle,
-            telescope.get_info().await.unwrap().status
-        );
-
-        // Start tracking again
-        stream.commands.clear();
-        telescope.target = TelescopeTarget::Galactic {
-            l: PI / 2.0,
-            b: 0.0,
-        };
-        telescope.update_direction(when, &mut stream).await.unwrap();
-        assert_eq!(
-            TelescopeStatus::Tracking,
-            telescope.get_info().await.unwrap().status
-        );
-
-        // Wait 5 minutes when source moves across the sky
-        let when = when + chrono::Duration::minutes(5);
-        stream.commands.clear();
-        telescope.update_direction(when, &mut stream).await.unwrap();
-        assert_eq!(
-            TelescopeStatus::Slewing,
-            telescope.get_info().await.unwrap().status
         );
     }
 }

--- a/backend/src/salsa_telescope.rs
+++ b/backend/src/salsa_telescope.rs
@@ -1,99 +1,19 @@
 use crate::telescope::Telescope;
+use crate::telescope_controller::TelescopeController;
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use common::coords::{horizontal_from_equatorial, horizontal_from_galactic};
+use chrono::Utc;
 use common::{
-    Direction, Location, Measurement, ObservedSpectra, ReceiverConfiguration, ReceiverError,
-    TelescopeError, TelescopeInfo, TelescopeStatus, TelescopeTarget,
+    Direction, Measurement, ObservedSpectra, ReceiverConfiguration, ReceiverError, TelescopeError,
+    TelescopeInfo, TelescopeTarget,
 };
-use hex_literal::hex;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpStream};
-use std::str::FromStr;
 use std::time::Duration;
 
 use rustfft::{num_complex::Complex, FftPlanner};
 use uhd::{self, StreamCommand, StreamCommandType, StreamTime, TuneRequest, Usrp};
-
-pub const LOWEST_ALLOWED_ALTITUDE: f64 = 5.0f64 / 180.0f64 * std::f64::consts::PI;
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum TelescopeCommand {
-    Stop,
-    Restart,
-    GetDirection,
-    SetDirection(Direction),
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum TelescopeResponse {
-    Ack,
-    CurrentDirection(Direction),
-}
-
-fn parse_ack_response(
-    bytes: &[u8],
-    command_name: &str,
-) -> Result<TelescopeResponse, TelescopeError> {
-    if bytes.len() == 12 && bytes[0] == 0x57 && bytes[11] == 0x20 {
-        Ok(TelescopeResponse::Ack)
-    } else {
-        Err(TelescopeError::TelescopeIOError(format!(
-            "Unexpected response to {} command: {:?}",
-            command_name, bytes,
-        )))
-    }
-}
-
-fn parse_direction_response(
-    bytes: &[u8],
-    command_name: &str,
-) -> Result<TelescopeResponse, TelescopeError> {
-    if bytes.len() == 12 && bytes[0] == 0x58 && bytes[11] == 0x20 {
-        let azimuth = rot2prog_bytes_to_angle(&bytes[1..=5]);
-        let altitude = rot2prog_bytes_to_angle(&bytes[6..=10]);
-        Ok(TelescopeResponse::CurrentDirection(Direction {
-            azimuth,
-            altitude,
-        }))
-    } else {
-        Err(TelescopeError::TelescopeIOError(format!(
-            "Unexpected response to {} command: {:?}",
-            command_name, bytes,
-        )))
-    }
-}
-
-impl TelescopeCommand {
-    fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            TelescopeCommand::Stop => hex!("57000000000000000000000F20").into(),
-            TelescopeCommand::Restart => hex!("57EFBEADDE000000000000EE20").into(),
-            TelescopeCommand::GetDirection => hex!("57000000000000000000006F20").into(),
-            TelescopeCommand::SetDirection(direction) => {
-                let mut bytes = Vec::with_capacity(13);
-                bytes.extend(hex!("57"));
-                bytes.extend(rot2prog_angle_to_bytes(direction.azimuth).as_slice());
-                bytes.extend(rot2prog_angle_to_bytes(direction.altitude).as_slice());
-                bytes.extend(hex!("5F20"));
-                bytes
-            }
-        }
-    }
-
-    fn parse_response(&self, bytes: &[u8]) -> Result<TelescopeResponse, TelescopeError> {
-        match self {
-            TelescopeCommand::Stop => parse_ack_response(bytes, "stop"),
-            TelescopeCommand::Restart => parse_ack_response(bytes, "restart"),
-            TelescopeCommand::GetDirection => parse_direction_response(bytes, "get direction"),
-            TelescopeCommand::SetDirection(_) => parse_direction_response(bytes, "set direction"),
-        }
-    }
-}
 
 pub struct ActiveIntegration {
     cancellation_token: CancellationToken,
@@ -102,19 +22,9 @@ pub struct ActiveIntegration {
 
 pub struct SalsaTelescope {
     name: String,
-    controller_address: String,
     receiver_address: String,
-    timeout: Duration,
-    target: TelescopeTarget,
-    commanded_horizontal: Option<Direction>,
-    current_direction: Option<Direction>,
-    location: Location,
-    most_recent_error: Option<TelescopeError>,
+    controller: TelescopeController,
     receiver_configuration: ReceiverConfiguration,
-    connection_established: bool,
-    lowest_allowed_altitude: f64,
-    telescope_restart_request_at: Option<DateTime<Utc>>,
-    wait_time_after_restart: chrono::Duration,
     measurements: Arc<Mutex<Vec<Measurement>>>,
     active_integration: Option<ActiveIntegration>,
 }
@@ -126,60 +36,12 @@ pub fn create(
 ) -> SalsaTelescope {
     SalsaTelescope {
         name,
-        controller_address,
         receiver_address,
-        timeout: Duration::from_secs(1),
-        target: TelescopeTarget::Stopped,
-        commanded_horizontal: None,
-        current_direction: None,
-        location: Location {
-            longitude: 0.20802143022, //(11.0+55.0/60.0+7.5/3600.0) * PI / 180.0. Sign positive, handled in gmst calc
-            latitude: 1.00170457462,  //(57.0+23.0/60.0+36.4/3600.0) * PI / 180.0
-        },
-        most_recent_error: None,
+        controller: TelescopeController::new(controller_address),
         receiver_configuration: ReceiverConfiguration { integrate: false },
-        connection_established: false,
-        lowest_allowed_altitude: LOWEST_ALLOWED_ALTITUDE,
-        telescope_restart_request_at: None,
-        wait_time_after_restart: chrono::Duration::seconds(10),
         measurements: Arc::new(Mutex::new(Vec::new())),
         active_integration: None,
     }
-}
-
-fn create_connection(telescope: &SalsaTelescope) -> Result<TcpStream, std::io::Error> {
-    let address = SocketAddr::from_str(telescope.controller_address.as_str()).unwrap();
-    let stream = TcpStream::connect_timeout(&address, telescope.timeout)?;
-    stream.set_read_timeout(Some(telescope.timeout))?;
-    stream.set_write_timeout(Some(telescope.timeout))?;
-    Ok(stream)
-}
-
-fn send_command<Stream>(
-    stream: &mut Stream,
-    command: TelescopeCommand,
-) -> Result<TelescopeResponse, TelescopeError>
-where
-    Stream: Read + Write,
-{
-    stream.write(&command.to_bytes()).unwrap();
-    let mut result = vec![0; 128];
-    let response_length = stream.read(&mut result).unwrap();
-    result.truncate(response_length);
-    command.parse_response(&result)
-}
-
-fn rot2prog_bytes_to_int(bytes: &[u8]) -> u32 {
-    bytes
-        .iter()
-        .rev()
-        .enumerate()
-        .map(|(pos, &digit)| digit as u32 * 10_u32.pow(pos as u32))
-        .sum()
-}
-
-fn rot2prog_bytes_to_angle(bytes: &[u8]) -> f64 {
-    (rot2prog_bytes_to_int(bytes) as f64 / 100.0 - 360.0).to_radians()
 }
 
 // Reading the documentation of the telescope, this should be the correct way to interpret the bytes
@@ -196,17 +58,6 @@ fn rot2prog_bytes_to_int_documented(bytes: &[u8]) -> u32 {
 #[allow(dead_code)]
 fn rot2prog_bytes_to_angle_documented(bytes: &[u8]) -> f64 {
     (rot2prog_bytes_to_int_documented(bytes) as f64 / 100.0 - 360.0).to_radians()
-}
-
-fn rot2prog_angle_to_bytes(angle: f64) -> [u8; 5] {
-    let mut bytes = [0; 5];
-    let angle = ((angle.to_degrees() + 360.0) * 100.0).round();
-    bytes[0] = (angle / 10000.0) as u8 + 0x30;
-    bytes[1] = ((angle % 10000.0) / 1000.0) as u8 + 0x30;
-    bytes[2] = ((angle % 1000.0) / 100.0) as u8 + 0x30;
-    bytes[3] = ((angle % 100.0) / 10.0) as u8 + 0x30;
-    bytes[4] = (angle % 10.0) as u8 + 0x30;
-    bytes
 }
 
 fn measure_switched(
@@ -405,25 +256,18 @@ async fn measure(
 #[async_trait]
 impl Telescope for SalsaTelescope {
     async fn get_direction(&self) -> Result<Direction, TelescopeError> {
-        let mut stream = create_connection(&self)?;
-
-        self.get_current_horizontal(&mut stream).await
+        self.controller.direction().await
     }
 
     async fn get_target(&self) -> Result<TelescopeTarget, TelescopeError> {
-        Ok(self.target)
+        self.controller.target()
     }
 
     async fn set_target(
         &mut self,
         target: TelescopeTarget,
     ) -> Result<TelescopeTarget, TelescopeError> {
-        let mut stream = create_connection(&self)?;
-
-        self.target = target;
-        self.update_direction(Utc::now(), &mut stream).await?;
-
-        Ok(target)
+        self.controller.set_target(target).await
     }
 
     async fn set_receiver_configuration(
@@ -447,8 +291,8 @@ impl Telescope for SalsaTelescope {
                 })
             };
             self.active_integration = Some(ActiveIntegration {
-                cancellation_token: cancellation_token,
-                measurement_task: measurement_task,
+                cancellation_token,
+                measurement_task,
             });
         } else if !receiver_configuration.integrate && self.receiver_configuration.integrate {
             log::info!("Stopping integration");
@@ -461,22 +305,7 @@ impl Telescope for SalsaTelescope {
     }
 
     async fn get_info(&self) -> Result<TelescopeInfo, TelescopeError> {
-        let current_horizontal = match self.current_direction {
-            Some(current_horizontal) => current_horizontal,
-            None => return Err(TelescopeError::TelescopeNotConnected),
-        };
-
-        let status = match self.commanded_horizontal {
-            Some(commanded_direction) => {
-                // Check if more than 2 tolerances off, if so we are not tracking anymore
-                if directions_are_close(commanded_direction, current_horizontal, 2.0) {
-                    TelescopeStatus::Tracking
-                } else {
-                    TelescopeStatus::Slewing
-                }
-            }
-            None => TelescopeStatus::Idle,
-        };
+        let controller_info = self.controller.info()?;
 
         let latest_observation = {
             let measurements = self.measurements.lock().await;
@@ -496,36 +325,17 @@ impl Telescope for SalsaTelescope {
 
         Ok(TelescopeInfo {
             id: self.name.clone(),
-            status,
-            current_horizontal,
-            commanded_horizontal: self.commanded_horizontal,
-            current_target: self.target,
-            most_recent_error: self.most_recent_error.clone(),
+            status: controller_info.status,
+            current_horizontal: controller_info.current_horizontal,
+            commanded_horizontal: controller_info.commanded_horizontal,
+            current_target: controller_info.target,
+            most_recent_error: controller_info.most_recent_error,
             measurement_in_progress: self.active_integration.is_some(),
-            latest_observation: latest_observation,
+            latest_observation,
         })
     }
 
     async fn update(&mut self, _delta_time: Duration) -> Result<(), TelescopeError> {
-        let now = Utc::now();
-        if let Some(telescope_restart_request_at) = self.telescope_restart_request_at {
-            if now - telescope_restart_request_at < self.wait_time_after_restart {
-                return Ok(());
-            } else {
-                self.telescope_restart_request_at = None;
-            }
-        }
-
-        let stream = create_connection(&self);
-        let mut stream = match stream {
-            Ok(stream) => stream,
-            Err(telescope_error) => {
-                let error: TelescopeError = telescope_error.into();
-                self.most_recent_error = Some(error.clone());
-                return Err(error);
-            }
-        };
-
         if let Some(active_integration) = self.active_integration.take() {
             if active_integration.measurement_task.is_finished() {
                 if let Err(error) = active_integration.measurement_task.await {
@@ -535,104 +345,12 @@ impl Telescope for SalsaTelescope {
                 self.active_integration = Some(active_integration);
             }
         }
-
-        self.update_direction(now, &mut stream).await?;
         Ok(())
     }
 
     async fn restart(&mut self) -> Result<(), TelescopeError> {
-        let mut stream = create_connection(&self)?;
-        send_command(&mut stream, TelescopeCommand::Restart)?;
-        self.most_recent_error = None;
-        self.connection_established = false;
-        self.telescope_restart_request_at = Some(Utc::now());
+        self.controller.restart();
         Ok(())
-    }
-}
-
-fn directions_are_close(a: Direction, b: Direction, tol: f64) -> bool {
-    // The salsa telescope works with a precision of 0.1 degrees
-    // We want to send new commands whenever we exceed this tolerance
-    // but to report tracking status we allow more, so that we do not flip
-    // status between tracking/slewing (e.g. due to control unit rounding errors)
-    // Therefore we have the "tol" multiplier here, which scales the allowed error.
-    let epsilon = tol * 0.1_f64.to_radians();
-    (a.azimuth - b.azimuth).abs() < epsilon && (a.altitude - b.altitude).abs() < epsilon
-}
-
-impl SalsaTelescope {
-    fn calculate_target_horizontal(&self, when: DateTime<Utc>) -> Option<Direction> {
-        match self.target {
-            TelescopeTarget::Equatorial { ra, dec } => {
-                Some(horizontal_from_equatorial(self.location, when, ra, dec))
-            }
-            TelescopeTarget::Galactic { l, b } => {
-                Some(horizontal_from_galactic(self.location, when, l, b))
-            }
-            TelescopeTarget::Stopped => None,
-            TelescopeTarget::Parked => None,
-        }
-    }
-
-    async fn get_current_horizontal<Stream>(
-        &self,
-        stream: &mut Stream,
-    ) -> Result<Direction, TelescopeError>
-    where
-        Stream: Read + Write,
-    {
-        match send_command(stream, TelescopeCommand::GetDirection)? {
-            TelescopeResponse::CurrentDirection(direction) => Ok(direction),
-            _ => Err(TelescopeError::TelescopeIOError(
-                "Telescope did not respond with current direction".to_string(),
-            )),
-        }
-    }
-
-    async fn update_direction<Stream>(
-        &mut self,
-        when: DateTime<Utc>,
-        stream: &mut Stream,
-    ) -> Result<(), TelescopeError>
-    where
-        Stream: Read + Write,
-    {
-        let target_horizontal = self.calculate_target_horizontal(when);
-        let current_horizontal = self.get_current_horizontal(stream).await?;
-        self.current_direction = Some(current_horizontal);
-
-        if !self.connection_established {
-            send_command(stream, TelescopeCommand::Stop)?;
-            self.commanded_horizontal = None;
-            self.connection_established = true;
-            return Ok(());
-        }
-
-        match target_horizontal {
-            Some(target_horizontal) => {
-                if target_horizontal.altitude < self.lowest_allowed_altitude {
-                    self.most_recent_error = Some(TelescopeError::TargetBelowHorizon);
-                    self.commanded_horizontal = None;
-                    return Err(TelescopeError::TargetBelowHorizon);
-                }
-
-                self.commanded_horizontal = Some(target_horizontal);
-
-                // Check if more than 1 tolerance off, if so we need to send track command
-                if !directions_are_close(target_horizontal, current_horizontal, 1.0) {
-                    send_command(stream, TelescopeCommand::SetDirection(target_horizontal))?;
-                }
-
-                Ok(())
-            }
-            None => {
-                if self.commanded_horizontal.is_some() {
-                    send_command(stream, TelescopeCommand::Stop)?;
-                    self.commanded_horizontal = None;
-                }
-                Ok(())
-            }
-        }
     }
 }
 

--- a/backend/src/telescope_controller.rs
+++ b/backend/src/telescope_controller.rs
@@ -1,0 +1,351 @@
+use chrono::{DateTime, Utc};
+use common::{Direction, Location, TelescopeError, TelescopeStatus, TelescopeTarget};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep_until, Instant};
+
+use common::coords::{horizontal_from_equatorial, horizontal_from_galactic};
+use hex_literal::hex;
+
+pub const LOWEST_ALLOWED_ALTITUDE: f64 = 5.0f64 / 180.0f64 * std::f64::consts::PI;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum TelescopeCommand {
+    Stop,
+    Restart,
+    GetDirection,
+    SetDirection(Direction),
+}
+
+fn parse_ack_response(
+    bytes: &[u8],
+    command_name: &str,
+) -> Result<TelescopeResponse, TelescopeError> {
+    if bytes.len() == 12 && bytes[0] == 0x57 && bytes[11] == 0x20 {
+        Ok(TelescopeResponse::Ack)
+    } else {
+        Err(TelescopeError::TelescopeIOError(format!(
+            "Unexpected response to {} command: {:?}",
+            command_name, bytes,
+        )))
+    }
+}
+
+fn parse_direction_response(
+    bytes: &[u8],
+    command_name: &str,
+) -> Result<TelescopeResponse, TelescopeError> {
+    if bytes.len() == 12 && bytes[0] == 0x58 && bytes[11] == 0x20 {
+        let azimuth = rot2prog_bytes_to_angle(&bytes[1..=5]);
+        let altitude = rot2prog_bytes_to_angle(&bytes[6..=10]);
+        Ok(TelescopeResponse::CurrentDirection(Direction {
+            azimuth,
+            altitude,
+        }))
+    } else {
+        Err(TelescopeError::TelescopeIOError(format!(
+            "Unexpected response to {} command: {:?}",
+            command_name, bytes,
+        )))
+    }
+}
+
+impl TelescopeCommand {
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            TelescopeCommand::Stop => hex!("57000000000000000000000F20").into(),
+            TelescopeCommand::Restart => hex!("57EFBEADDE000000000000EE20").into(),
+            TelescopeCommand::GetDirection => hex!("57000000000000000000006F20").into(),
+            TelescopeCommand::SetDirection(direction) => {
+                let mut bytes = Vec::with_capacity(13);
+                bytes.extend(hex!("57"));
+                bytes.extend(rot2prog_angle_to_bytes(direction.azimuth).as_slice());
+                bytes.extend(rot2prog_angle_to_bytes(direction.altitude).as_slice());
+                bytes.extend(hex!("5F20"));
+                bytes
+            }
+        }
+    }
+
+    fn parse_response(&self, bytes: &[u8]) -> Result<TelescopeResponse, TelescopeError> {
+        match self {
+            TelescopeCommand::Stop => parse_ack_response(bytes, "stop"),
+            TelescopeCommand::Restart => parse_ack_response(bytes, "restart"),
+            TelescopeCommand::GetDirection => parse_direction_response(bytes, "get direction"),
+            TelescopeCommand::SetDirection(_) => parse_direction_response(bytes, "set direction"),
+        }
+    }
+}
+
+fn create_connection(state: &TelescopeControllerState) -> Result<TcpStream, std::io::Error> {
+    // FIXME: How to handle static configuration like timeouts etc?
+    let timeout = Duration::from_secs(1);
+    let address = SocketAddr::from_str(state.controller_address.as_str()).unwrap();
+    let stream = TcpStream::connect_timeout(&address, timeout)?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    Ok(stream)
+}
+
+fn send_command<Stream>(
+    stream: &mut Stream,
+    command: TelescopeCommand,
+) -> Result<TelescopeResponse, TelescopeError>
+where
+    Stream: Read + Write,
+{
+    stream.write(&command.to_bytes()).unwrap();
+    let mut result = vec![0; 128];
+    let response_length = stream.read(&mut result).unwrap();
+    result.truncate(response_length);
+    command.parse_response(&result)
+}
+
+fn rot2prog_bytes_to_int(bytes: &[u8]) -> u32 {
+    bytes
+        .iter()
+        .rev()
+        .enumerate()
+        .map(|(pos, &digit)| digit as u32 * 10_u32.pow(pos as u32))
+        .sum()
+}
+
+fn rot2prog_bytes_to_angle(bytes: &[u8]) -> f64 {
+    (rot2prog_bytes_to_int(bytes) as f64 / 100.0 - 360.0).to_radians()
+}
+
+fn rot2prog_angle_to_bytes(angle: f64) -> [u8; 5] {
+    let mut bytes = [0; 5];
+    let angle = ((angle.to_degrees() + 360.0) * 100.0).round();
+    bytes[0] = (angle / 10000.0) as u8 + 0x30;
+    bytes[1] = ((angle % 10000.0) / 1000.0) as u8 + 0x30;
+    bytes[2] = ((angle % 1000.0) / 100.0) as u8 + 0x30;
+    bytes[3] = ((angle % 100.0) / 10.0) as u8 + 0x30;
+    bytes[4] = (angle % 10.0) as u8 + 0x30;
+    bytes
+}
+
+fn directions_are_close(a: Direction, b: Direction, tol: f64) -> bool {
+    // The salsa telescope works with a precision of 0.1 degrees
+    // We want to send new commands whenever we exceed this tolerance
+    // but to report tracking status we allow more, so that we do not flip
+    // status between tracking/slewing (e.g. due to control unit rounding errors)
+    // Therefore we have the "tol" multiplier here, which scales the allowed error.
+    let epsilon = tol * 0.1_f64.to_radians();
+    (a.azimuth - b.azimuth).abs() < epsilon && (a.altitude - b.altitude).abs() < epsilon
+}
+
+pub struct TelescopeControllerInfo {
+    pub target: TelescopeTarget,
+    pub commanded_horizontal: Option<Direction>,
+    pub current_horizontal: Direction,
+    pub status: TelescopeStatus,
+    pub most_recent_error: Option<TelescopeError>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum TelescopeResponse {
+    Ack,
+    CurrentDirection(Direction),
+}
+
+struct TelescopeControllerState {
+    controller_address: String,
+    target: TelescopeTarget,
+    commanded_horizontal: Option<Direction>,
+    current_direction: Option<Direction>,
+    most_recent_error: Option<TelescopeError>,
+    should_restart: bool,
+}
+
+pub struct TelescopeController {
+    // FIXME: Do we need to lock the whole state at a time?
+    state: Arc<Mutex<TelescopeControllerState>>,
+}
+
+impl TelescopeController {
+    pub fn new(controller_address: String) -> TelescopeController {
+        let state = Arc::new(Mutex::new(TelescopeControllerState {
+            controller_address,
+            target: TelescopeTarget::Stopped,
+            commanded_horizontal: None,
+            current_direction: None,
+            most_recent_error: None,
+            should_restart: false,
+        }));
+        // FIXME: Keep track of this task and do a proper shutdown.
+        let _ = spawn_controller_task(state.clone());
+        TelescopeController { state }
+    }
+
+    pub async fn direction(&self) -> Result<Direction, TelescopeError> {
+        match self.state.lock().unwrap().current_direction {
+            Some(current_direction) => Ok(current_direction),
+            None => return Err(TelescopeError::TelescopeNotConnected),
+        }
+    }
+
+    pub fn target(&self) -> Result<TelescopeTarget, TelescopeError> {
+        Ok(self.state.lock().unwrap().target)
+    }
+
+    pub async fn set_target(
+        &mut self,
+        target: TelescopeTarget,
+    ) -> Result<TelescopeTarget, TelescopeError> {
+        self.state.lock().unwrap().target = target;
+        Ok(target)
+    }
+
+    pub fn info(&self) -> Result<TelescopeControllerInfo, TelescopeError> {
+        let current_horizontal = match self.state.lock().unwrap().current_direction {
+            Some(current_horizontal) => current_horizontal,
+            None => return Err(TelescopeError::TelescopeNotConnected),
+        };
+
+        let status = match self.commanded_horizontal() {
+            Some(commanded_direction) => {
+                // Check if more than 2 tolerances off, if so we are not tracking anymore
+                if directions_are_close(commanded_direction, current_horizontal, 2.0) {
+                    TelescopeStatus::Tracking
+                } else {
+                    TelescopeStatus::Slewing
+                }
+            }
+            None => TelescopeStatus::Idle,
+        };
+        Ok(TelescopeControllerInfo {
+            target: self.state.lock().unwrap().target,
+            current_horizontal,
+            commanded_horizontal: self.commanded_horizontal(),
+            status,
+            most_recent_error: self.state.lock().unwrap().most_recent_error.clone(),
+        })
+    }
+
+    pub fn restart(&self) {
+        self.state.lock().unwrap().should_restart = true;
+    }
+
+    fn commanded_horizontal(&self) -> Option<Direction> {
+        self.state.lock().unwrap().commanded_horizontal
+    }
+}
+
+fn update_direction<Stream>(
+    state: &mut TelescopeControllerState,
+    when: DateTime<Utc>,
+    stream: &mut Stream,
+) -> Result<(), TelescopeError>
+where
+    Stream: Read + Write,
+{
+    // FIXME: How do we handle static configuration like this?
+    let location = Location {
+        longitude: 0.20802143022, //(11.0+55.0/60.0+7.5/3600.0) * PI / 180.0. Sign positive, handled in gmst calc
+        latitude: 1.00170457462,  //(57.0+23.0/60.0+36.4/3600.0) * PI / 180.0
+    };
+    let target_horizontal = calculate_target_horizontal(state.target, location, when);
+    let current_horizontal = get_current_horizontal(stream)?;
+    state.current_direction = Some(current_horizontal);
+
+    match target_horizontal {
+        Some(target_horizontal) => {
+            // FIXME: How to handle static configuration like this?
+            if target_horizontal.altitude < LOWEST_ALLOWED_ALTITUDE {
+                state.most_recent_error = Some(TelescopeError::TargetBelowHorizon);
+                state.commanded_horizontal = None;
+                return Err(TelescopeError::TargetBelowHorizon);
+            }
+
+            state.commanded_horizontal = Some(target_horizontal);
+
+            // Check if more than 1 tolerance off, if so we need to send track command
+            if !directions_are_close(target_horizontal, current_horizontal, 1.0) {
+                send_command(stream, TelescopeCommand::SetDirection(target_horizontal))?;
+            }
+
+            Ok(())
+        }
+        None => {
+            if state.commanded_horizontal.is_some() {
+                send_command(stream, TelescopeCommand::Stop)?;
+                state.commanded_horizontal = None;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn calculate_target_horizontal(
+    target: TelescopeTarget,
+    location: Location,
+    when: DateTime<Utc>,
+) -> Option<Direction> {
+    match target {
+        TelescopeTarget::Equatorial { ra, dec } => {
+            Some(horizontal_from_equatorial(location, when, ra, dec))
+        }
+        TelescopeTarget::Galactic { l, b } => Some(horizontal_from_galactic(location, when, l, b)),
+        TelescopeTarget::Stopped => None,
+        TelescopeTarget::Parked => None,
+    }
+}
+
+fn get_current_horizontal<Stream>(stream: &mut Stream) -> Result<Direction, TelescopeError>
+where
+    Stream: Read + Write,
+{
+    match send_command(stream, TelescopeCommand::GetDirection)? {
+        TelescopeResponse::CurrentDirection(direction) => Ok(direction),
+        _ => Err(TelescopeError::TelescopeIOError(
+            "Telescope did not respond with current direction".to_string(),
+        )),
+    }
+}
+
+fn spawn_controller_task(state: Arc<Mutex<TelescopeControllerState>>) -> JoinHandle<()> {
+    tokio::spawn(controller_task_function(state))
+}
+
+async fn controller_task_function(state: Arc<Mutex<TelescopeControllerState>>) {
+    // commanded_horizontal: Option<Direction>,
+    let mut connection_established = false;
+
+    loop {
+        // 10 Hz update freq
+        sleep_until(Instant::now() + Duration::from_millis(100)).await;
+
+        let stream = create_connection(&state.lock().unwrap());
+        let mut stream = match stream {
+            Ok(stream) => stream,
+            Err(telescope_error) => {
+                let error: TelescopeError = telescope_error.into();
+                state.lock().unwrap().most_recent_error = Some(error.clone());
+                continue;
+            }
+        };
+        if !connection_established {
+            let mut state_guard = state.lock().unwrap();
+            state_guard.most_recent_error = send_command(&mut stream, TelescopeCommand::Stop).err();
+            state_guard.commanded_horizontal = None;
+            connection_established = true;
+        }
+
+        if state.lock().unwrap().should_restart {
+            state.lock().unwrap().most_recent_error =
+                send_command(&mut stream, TelescopeCommand::Restart).err();
+            connection_established = false;
+            sleep_until(Instant::now() + Duration::from_secs(10)).await;
+            state.lock().unwrap().should_restart = false;
+            continue;
+        }
+
+        let res = update_direction(&mut state.lock().unwrap(), Utc::now(), &mut stream);
+        state.lock().unwrap().most_recent_error = res.err();
+    }
+}

--- a/backend/src/telescope_controller.rs
+++ b/backend/src/telescope_controller.rs
@@ -1,24 +1,74 @@
-use chrono::{DateTime, Utc};
-use common::{Direction, Location, TelescopeError, TelescopeStatus, TelescopeTarget};
+use common::{Direction, TelescopeError};
+use hex_literal::hex;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::task::JoinHandle;
-use tokio::time::{sleep_until, Instant};
-
-use common::coords::{horizontal_from_equatorial, horizontal_from_galactic};
-use hex_literal::hex;
-
-pub const LOWEST_ALLOWED_ALTITUDE: f64 = 5.0f64 / 180.0f64 * std::f64::consts::PI;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-enum TelescopeCommand {
+pub enum TelescopeCommand {
     Stop,
     Restart,
     GetDirection,
     SetDirection(Direction),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TelescopeResponse {
+    Ack,
+    CurrentDirection(Direction),
+}
+
+pub struct TelescopeController {
+    // FIXME: Do we need to be able to mock at this level?
+    stream: TcpStream,
+}
+
+impl TelescopeController {
+    pub fn connect(address: &str) -> Result<TelescopeController, TelescopeError> {
+        let stream = create_connection(address)?;
+        Ok(TelescopeController { stream })
+    }
+
+    pub fn execute(
+        &mut self,
+        command: TelescopeCommand,
+    ) -> Result<TelescopeResponse, TelescopeError> {
+        // FIXME: Handle connection failure.
+        self.stream.write(&command.to_bytes()).unwrap();
+        let mut result = vec![0; 128];
+        // FIXME: Handle connection failure.
+        let response_length = self.stream.read(&mut result).unwrap();
+        result.truncate(response_length);
+        command.parse_response(&result)
+    }
+}
+
+impl TelescopeCommand {
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            TelescopeCommand::Stop => hex!("57000000000000000000000F20").into(),
+            TelescopeCommand::Restart => hex!("57EFBEADDE000000000000EE20").into(),
+            TelescopeCommand::GetDirection => hex!("57000000000000000000006F20").into(),
+            TelescopeCommand::SetDirection(direction) => {
+                let mut bytes = Vec::with_capacity(13);
+                bytes.extend(hex!("57"));
+                bytes.extend(rot2prog_angle_to_bytes(direction.azimuth).as_slice());
+                bytes.extend(rot2prog_angle_to_bytes(direction.altitude).as_slice());
+                bytes.extend(hex!("5F20"));
+                bytes
+            }
+        }
+    }
+
+    fn parse_response(&self, bytes: &[u8]) -> Result<TelescopeResponse, TelescopeError> {
+        match self {
+            TelescopeCommand::Stop => parse_ack_response(bytes, "stop"),
+            TelescopeCommand::Restart => parse_ack_response(bytes, "restart"),
+            TelescopeCommand::GetDirection => parse_direction_response(bytes, "get direction"),
+            TelescopeCommand::SetDirection(_) => parse_direction_response(bytes, "set direction"),
+        }
+    }
 }
 
 fn parse_ack_response(
@@ -54,55 +104,14 @@ fn parse_direction_response(
     }
 }
 
-impl TelescopeCommand {
-    fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            TelescopeCommand::Stop => hex!("57000000000000000000000F20").into(),
-            TelescopeCommand::Restart => hex!("57EFBEADDE000000000000EE20").into(),
-            TelescopeCommand::GetDirection => hex!("57000000000000000000006F20").into(),
-            TelescopeCommand::SetDirection(direction) => {
-                let mut bytes = Vec::with_capacity(13);
-                bytes.extend(hex!("57"));
-                bytes.extend(rot2prog_angle_to_bytes(direction.azimuth).as_slice());
-                bytes.extend(rot2prog_angle_to_bytes(direction.altitude).as_slice());
-                bytes.extend(hex!("5F20"));
-                bytes
-            }
-        }
-    }
-
-    fn parse_response(&self, bytes: &[u8]) -> Result<TelescopeResponse, TelescopeError> {
-        match self {
-            TelescopeCommand::Stop => parse_ack_response(bytes, "stop"),
-            TelescopeCommand::Restart => parse_ack_response(bytes, "restart"),
-            TelescopeCommand::GetDirection => parse_direction_response(bytes, "get direction"),
-            TelescopeCommand::SetDirection(_) => parse_direction_response(bytes, "set direction"),
-        }
-    }
-}
-
-fn create_connection(state: &TelescopeControllerState) -> Result<TcpStream, std::io::Error> {
+fn create_connection(address: &str) -> Result<TcpStream, std::io::Error> {
     // FIXME: How to handle static configuration like timeouts etc?
     let timeout = Duration::from_secs(1);
-    let address = SocketAddr::from_str(state.controller_address.as_str()).unwrap();
+    let address = SocketAddr::from_str(address).unwrap();
     let stream = TcpStream::connect_timeout(&address, timeout)?;
     stream.set_read_timeout(Some(timeout))?;
     stream.set_write_timeout(Some(timeout))?;
     Ok(stream)
-}
-
-fn send_command<Stream>(
-    stream: &mut Stream,
-    command: TelescopeCommand,
-) -> Result<TelescopeResponse, TelescopeError>
-where
-    Stream: Read + Write,
-{
-    stream.write(&command.to_bytes()).unwrap();
-    let mut result = vec![0; 128];
-    let response_length = stream.read(&mut result).unwrap();
-    result.truncate(response_length);
-    command.parse_response(&result)
 }
 
 fn rot2prog_bytes_to_int(bytes: &[u8]) -> u32 {
@@ -129,223 +138,97 @@ fn rot2prog_angle_to_bytes(angle: f64) -> [u8; 5] {
     bytes
 }
 
-fn directions_are_close(a: Direction, b: Direction, tol: f64) -> bool {
-    // The salsa telescope works with a precision of 0.1 degrees
-    // We want to send new commands whenever we exceed this tolerance
-    // but to report tracking status we allow more, so that we do not flip
-    // status between tracking/slewing (e.g. due to control unit rounding errors)
-    // Therefore we have the "tol" multiplier here, which scales the allowed error.
-    let epsilon = tol * 0.1_f64.to_radians();
-    (a.azimuth - b.azimuth).abs() < epsilon && (a.altitude - b.altitude).abs() < epsilon
-}
+#[cfg(test)]
+mod test {
+    use super::*;
 
-pub struct TelescopeControllerInfo {
-    pub target: TelescopeTarget,
-    pub commanded_horizontal: Option<Direction>,
-    pub current_horizontal: Direction,
-    pub status: TelescopeStatus,
-    pub most_recent_error: Option<TelescopeError>,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum TelescopeResponse {
-    Ack,
-    CurrentDirection(Direction),
-}
-
-struct TelescopeControllerState {
-    controller_address: String,
-    target: TelescopeTarget,
-    commanded_horizontal: Option<Direction>,
-    current_direction: Option<Direction>,
-    most_recent_error: Option<TelescopeError>,
-    should_restart: bool,
-}
-
-pub struct TelescopeController {
-    // FIXME: Do we need to lock the whole state at a time?
-    state: Arc<Mutex<TelescopeControllerState>>,
-}
-
-impl TelescopeController {
-    pub fn new(controller_address: String) -> TelescopeController {
-        let state = Arc::new(Mutex::new(TelescopeControllerState {
-            controller_address,
-            target: TelescopeTarget::Stopped,
-            commanded_horizontal: None,
-            current_direction: None,
-            most_recent_error: None,
-            should_restart: false,
-        }));
-        // FIXME: Keep track of this task and do a proper shutdown.
-        let _ = spawn_controller_task(state.clone());
-        TelescopeController { state }
+    #[test]
+    fn test_parse_ack_response() {
+        let res = parse_ack_response(&hex!("570000000000000000000020"), "test").unwrap();
+        assert_eq!(res, TelescopeResponse::Ack);
+        let res = parse_ack_response(&hex!("560000000000000000000020"), "test");
+        assert_eq!(
+            res,
+            Err(TelescopeError::TelescopeIOError(
+                "Unexpected response to test command: [86, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32]"
+                    .to_string()
+            ))
+        );
+        let res = parse_ack_response(&hex!("5700000000000000000020"), "test");
+        assert_eq!(
+            res,
+            Err(TelescopeError::TelescopeIOError(
+                "Unexpected response to test command: [87, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32]"
+                    .to_string()
+            ))
+        );
     }
 
-    pub async fn direction(&self) -> Result<Direction, TelescopeError> {
-        match self.state.lock().unwrap().current_direction {
-            Some(current_direction) => Ok(current_direction),
-            None => return Err(TelescopeError::TelescopeNotConnected),
-        }
+    #[test]
+    fn test_parse_direction_response() {
+        let res =
+            parse_direction_response(&hex!("58 03 06 00 00 00 03 06 00 00 00 20"), "test").unwrap();
+        assert_eq!(
+            res,
+            TelescopeResponse::CurrentDirection(Direction {
+                azimuth: 0.0,
+                altitude: 0.0,
+            })
+        );
+    }
+    #[test]
+    fn test_rot2prog_bytes_to_int() {
+        assert_eq!(
+            rot2prog_bytes_to_int(&hex!("00")),
+            0
+        );
+        assert_eq!(
+            rot2prog_bytes_to_int(&hex!("01")),
+            1
+        );
+        assert_eq!(
+            rot2prog_bytes_to_int(&hex!("00 01")),
+            1
+        );
+        assert_eq!(
+            rot2prog_bytes_to_int(&hex!("01 02")),
+            12
+        );
+        assert_eq!(
+            rot2prog_bytes_to_int(&hex!("09 09 09")),
+            999
+        );
     }
 
-    pub fn target(&self) -> Result<TelescopeTarget, TelescopeError> {
-        Ok(self.state.lock().unwrap().target)
+    #[test]
+    fn test_rot2prog_angle_to_bytes() {
+        assert_eq!(
+            rot2prog_angle_to_bytes(0.0),
+            hex!("3336303030"),
+            "0.0 should be 0x3336303030 (telescope expects angle + 360)"
+        );
+        assert_eq!(
+            rot2prog_angle_to_bytes(5.54_f64.to_radians()),
+            hex!("3336353534"),
+            "5.54 should be 0x3336353534 (example from documentation)"
+        );
     }
 
-    pub async fn set_target(
-        &mut self,
-        target: TelescopeTarget,
-    ) -> Result<TelescopeTarget, TelescopeError> {
-        self.state.lock().unwrap().target = target;
-        Ok(target)
+    #[test]
+    fn test_rot2prog_bytes_to_angle() {
+        assert!((rot2prog_bytes_to_angle(&hex!("0306000000")) - 0.0).abs() < 0.01,);
     }
 
-    pub fn info(&self) -> Result<TelescopeControllerInfo, TelescopeError> {
-        let current_horizontal = match self.state.lock().unwrap().current_direction {
-            Some(current_horizontal) => current_horizontal,
-            None => return Err(TelescopeError::TelescopeNotConnected),
-        };
-
-        let status = match self.commanded_horizontal() {
-            Some(commanded_direction) => {
-                // Check if more than 2 tolerances off, if so we are not tracking anymore
-                if directions_are_close(commanded_direction, current_horizontal, 2.0) {
-                    TelescopeStatus::Tracking
-                } else {
-                    TelescopeStatus::Slewing
-                }
-            }
-            None => TelescopeStatus::Idle,
-        };
-        Ok(TelescopeControllerInfo {
-            target: self.state.lock().unwrap().target,
-            current_horizontal,
-            commanded_horizontal: self.commanded_horizontal(),
-            status,
-            most_recent_error: self.state.lock().unwrap().most_recent_error.clone(),
-        })
-    }
-
-    pub fn restart(&self) {
-        self.state.lock().unwrap().should_restart = true;
-    }
-
-    fn commanded_horizontal(&self) -> Option<Direction> {
-        self.state.lock().unwrap().commanded_horizontal
-    }
-}
-
-fn update_direction<Stream>(
-    state: &mut TelescopeControllerState,
-    when: DateTime<Utc>,
-    stream: &mut Stream,
-) -> Result<(), TelescopeError>
-where
-    Stream: Read + Write,
-{
-    // FIXME: How do we handle static configuration like this?
-    let location = Location {
-        longitude: 0.20802143022, //(11.0+55.0/60.0+7.5/3600.0) * PI / 180.0. Sign positive, handled in gmst calc
-        latitude: 1.00170457462,  //(57.0+23.0/60.0+36.4/3600.0) * PI / 180.0
-    };
-    let target_horizontal = calculate_target_horizontal(state.target, location, when);
-    let current_horizontal = get_current_horizontal(stream)?;
-    state.current_direction = Some(current_horizontal);
-
-    match target_horizontal {
-        Some(target_horizontal) => {
-            // FIXME: How to handle static configuration like this?
-            if target_horizontal.altitude < LOWEST_ALLOWED_ALTITUDE {
-                state.most_recent_error = Some(TelescopeError::TargetBelowHorizon);
-                state.commanded_horizontal = None;
-                return Err(TelescopeError::TargetBelowHorizon);
-            }
-
-            state.commanded_horizontal = Some(target_horizontal);
-
-            // Check if more than 1 tolerance off, if so we need to send track command
-            if !directions_are_close(target_horizontal, current_horizontal, 1.0) {
-                send_command(stream, TelescopeCommand::SetDirection(target_horizontal))?;
-            }
-
-            Ok(())
-        }
-        None => {
-            if state.commanded_horizontal.is_some() {
-                send_command(stream, TelescopeCommand::Stop)?;
-                state.commanded_horizontal = None;
-            }
-            Ok(())
-        }
-    }
-}
-
-fn calculate_target_horizontal(
-    target: TelescopeTarget,
-    location: Location,
-    when: DateTime<Utc>,
-) -> Option<Direction> {
-    match target {
-        TelescopeTarget::Equatorial { ra, dec } => {
-            Some(horizontal_from_equatorial(location, when, ra, dec))
-        }
-        TelescopeTarget::Galactic { l, b } => Some(horizontal_from_galactic(location, when, l, b)),
-        TelescopeTarget::Stopped => None,
-        TelescopeTarget::Parked => None,
-    }
-}
-
-fn get_current_horizontal<Stream>(stream: &mut Stream) -> Result<Direction, TelescopeError>
-where
-    Stream: Read + Write,
-{
-    match send_command(stream, TelescopeCommand::GetDirection)? {
-        TelescopeResponse::CurrentDirection(direction) => Ok(direction),
-        _ => Err(TelescopeError::TelescopeIOError(
-            "Telescope did not respond with current direction".to_string(),
-        )),
-    }
-}
-
-fn spawn_controller_task(state: Arc<Mutex<TelescopeControllerState>>) -> JoinHandle<()> {
-    tokio::spawn(controller_task_function(state))
-}
-
-async fn controller_task_function(state: Arc<Mutex<TelescopeControllerState>>) {
-    // commanded_horizontal: Option<Direction>,
-    let mut connection_established = false;
-
-    loop {
-        // 10 Hz update freq
-        sleep_until(Instant::now() + Duration::from_millis(100)).await;
-
-        let stream = create_connection(&state.lock().unwrap());
-        let mut stream = match stream {
-            Ok(stream) => stream,
-            Err(telescope_error) => {
-                let error: TelescopeError = telescope_error.into();
-                state.lock().unwrap().most_recent_error = Some(error.clone());
-                continue;
-            }
-        };
-        if !connection_established {
-            let mut state_guard = state.lock().unwrap();
-            state_guard.most_recent_error = send_command(&mut stream, TelescopeCommand::Stop).err();
-            state_guard.commanded_horizontal = None;
-            connection_established = true;
-        }
-
-        if state.lock().unwrap().should_restart {
-            state.lock().unwrap().most_recent_error =
-                send_command(&mut stream, TelescopeCommand::Restart).err();
-            connection_established = false;
-            sleep_until(Instant::now() + Duration::from_secs(10)).await;
-            state.lock().unwrap().should_restart = false;
-            continue;
-        }
-
-        let res = update_direction(&mut state.lock().unwrap(), Utc::now(), &mut stream);
-        state.lock().unwrap().most_recent_error = res.err();
+    // Responses are documented as ascii encoded numbers, but the telescope seems to return the
+    // bytes directly.
+    fn rot2prog_response_angle_to_bytes(angle: f64) -> [u8; 5] {
+        let mut bytes = [0; 5];
+        let angle = ((angle.to_degrees() + 360.0) * 100.0).round();
+        bytes[0] = (angle / 10000.0) as u8;
+        bytes[1] = ((angle % 10000.0) / 1000.0) as u8;
+        bytes[2] = ((angle % 1000.0) / 100.0) as u8;
+        bytes[3] = ((angle % 100.0) / 10.0) as u8;
+        bytes[4] = (angle % 10.0) as u8;
+        bytes
     }
 }

--- a/backend/src/telescope_controller.rs
+++ b/backend/src/telescope_controller.rs
@@ -178,26 +178,11 @@ mod test {
     }
     #[test]
     fn test_rot2prog_bytes_to_int() {
-        assert_eq!(
-            rot2prog_bytes_to_int(&hex!("00")),
-            0
-        );
-        assert_eq!(
-            rot2prog_bytes_to_int(&hex!("01")),
-            1
-        );
-        assert_eq!(
-            rot2prog_bytes_to_int(&hex!("00 01")),
-            1
-        );
-        assert_eq!(
-            rot2prog_bytes_to_int(&hex!("01 02")),
-            12
-        );
-        assert_eq!(
-            rot2prog_bytes_to_int(&hex!("09 09 09")),
-            999
-        );
+        assert_eq!(rot2prog_bytes_to_int(&hex!("00")), 0);
+        assert_eq!(rot2prog_bytes_to_int(&hex!("01")), 1);
+        assert_eq!(rot2prog_bytes_to_int(&hex!("00 01")), 1);
+        assert_eq!(rot2prog_bytes_to_int(&hex!("01 02")), 12);
+        assert_eq!(rot2prog_bytes_to_int(&hex!("09 09 09")), 999);
     }
 
     #[test]

--- a/backend/src/telescope_routes.rs
+++ b/backend/src/telescope_routes.rs
@@ -113,15 +113,16 @@ mod handlers {
 
     pub async fn get_telescopes(telescopes: TelescopeCollection) -> Result<impl Reply, Rejection> {
         let mut telescope_infos = Vec::<TelescopeInfo>::new();
-        {
-            let telescopes = telescopes.read().await;
-            for telescope in telescopes.values() {
-                let telescope = telescope.telescope.lock().await;
-                if let Ok(info) = telescope.get_info().await {
-                    telescope_infos.push(info);
-                }
+        for (name, telescope) in telescopes.read().await.iter() {
+            log::trace!("Checking {}", name);
+            let telescope = telescope.telescope.lock().await;
+            if let Ok(info) = telescope.get_info().await {
+                log::trace!("Accepted {}", name);
+                telescope_infos.push(info);
+            } else {
+                log::trace!("Rejected {}", name);
             }
-        };
+        }
         Ok(warp::reply::json(&telescope_infos))
     }
 

--- a/backend/src/telescope_tracker.rs
+++ b/backend/src/telescope_tracker.rs
@@ -1,0 +1,208 @@
+use crate::telescope_controller::{TelescopeCommand, TelescopeController, TelescopeResponse};
+use chrono::{DateTime, Utc};
+use common::coords::{horizontal_from_equatorial, horizontal_from_galactic};
+use common::{Direction, Location, TelescopeError, TelescopeStatus, TelescopeTarget};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::time::{sleep_until, Instant};
+
+pub const LOWEST_ALLOWED_ALTITUDE: f64 = 5.0f64 / 180.0f64 * std::f64::consts::PI;
+
+pub struct TelescopeTrackerInfo {
+    pub target: TelescopeTarget,
+    pub commanded_horizontal: Option<Direction>,
+    pub current_horizontal: Direction,
+    pub status: TelescopeStatus,
+    pub most_recent_error: Option<TelescopeError>,
+}
+
+pub struct TelescopeTracker {
+    // FIXME: Do we need to lock the whole state at a time?
+    state: Arc<Mutex<TelescopeTrackerState>>,
+}
+
+impl TelescopeTracker {
+    pub fn new(controller_address: String) -> TelescopeTracker {
+        let state = Arc::new(Mutex::new(TelescopeTrackerState {
+            target: TelescopeTarget::Stopped,
+            commanded_horizontal: None,
+            current_direction: None,
+            most_recent_error: None,
+            should_restart: false,
+        }));
+        // FIXME: Keep track of this task and do a proper shutdown.
+        tokio::spawn(tracker_task_function(state.clone(), controller_address));
+        TelescopeTracker { state }
+    }
+
+    pub fn set_target(
+        &mut self,
+        target: TelescopeTarget,
+    ) -> Result<TelescopeTarget, TelescopeError> {
+        self.state.lock().unwrap().target = target;
+        Ok(target)
+    }
+
+    pub fn restart(&self) {
+        self.state.lock().unwrap().should_restart = true;
+    }
+
+    pub fn info(&self) -> Result<TelescopeTrackerInfo, TelescopeError> {
+        let current_horizontal = match self.state.lock().unwrap().current_direction {
+            Some(current_horizontal) => current_horizontal,
+            None => return Err(TelescopeError::TelescopeNotConnected),
+        };
+        let status = match self.commanded_horizontal() {
+            Some(commanded_horizontal) => {
+                // Check if more than 2 tolerances off, if so we are not tracking anymore
+                if directions_are_close(commanded_horizontal, current_horizontal, 2.0) {
+                    TelescopeStatus::Tracking
+                } else {
+                    TelescopeStatus::Slewing
+                }
+            }
+            None => TelescopeStatus::Idle,
+        };
+        Ok(TelescopeTrackerInfo {
+            target: self.state.lock().unwrap().target,
+            current_horizontal,
+            commanded_horizontal: self.commanded_horizontal(),
+            status,
+            most_recent_error: self.state.lock().unwrap().most_recent_error.clone(),
+        })
+    }
+
+    pub fn direction(&self) -> Result<Direction, TelescopeError> {
+        match self.state.lock().unwrap().current_direction {
+            Some(current_direction) => Ok(current_direction),
+            None => return Err(TelescopeError::TelescopeNotConnected),
+        }
+    }
+
+    pub fn target(&self) -> Result<TelescopeTarget, TelescopeError> {
+        Ok(self.state.lock().unwrap().target)
+    }
+
+    fn commanded_horizontal(&self) -> Option<Direction> {
+        self.state.lock().unwrap().commanded_horizontal
+    }
+}
+
+struct TelescopeTrackerState {
+    target: TelescopeTarget,
+    commanded_horizontal: Option<Direction>,
+    current_direction: Option<Direction>,
+    most_recent_error: Option<TelescopeError>,
+    should_restart: bool,
+}
+
+async fn tracker_task_function(
+    state: Arc<Mutex<TelescopeTrackerState>>,
+    controller_address: String,
+) {
+    let mut connection_established = false;
+
+    loop {
+        // 10 Hz update freq
+        sleep_until(Instant::now() + Duration::from_millis(100)).await;
+
+        let mut controller = match TelescopeController::connect(&controller_address) {
+            Ok(controller) => controller,
+            Err(err) => {
+                state.lock().unwrap().most_recent_error = Some(err);
+                continue;
+            }
+        };
+
+        if !connection_established {
+            let mut state_guard = state.lock().unwrap();
+            state_guard.most_recent_error = controller.execute(TelescopeCommand::Stop).err();
+            state_guard.commanded_horizontal = None;
+            connection_established = true;
+        }
+
+        if state.lock().unwrap().should_restart {
+            state.lock().unwrap().most_recent_error =
+                controller.execute(TelescopeCommand::Restart).err();
+            connection_established = false;
+            sleep_until(Instant::now() + Duration::from_secs(10)).await;
+            state.lock().unwrap().should_restart = false;
+            continue;
+        }
+
+        let res = update_direction(&mut state.lock().unwrap(), Utc::now(), &mut controller);
+        state.lock().unwrap().most_recent_error = res.err();
+    }
+}
+
+fn update_direction(
+    state: &mut TelescopeTrackerState,
+    when: DateTime<Utc>,
+    controller: &mut TelescopeController,
+) -> Result<(), TelescopeError> {
+    // FIXME: How do we handle static configuration like this?
+    let location = Location {
+        longitude: 0.20802143022, //(11.0+55.0/60.0+7.5/3600.0) * PI / 180.0. Sign positive, handled in gmst calc
+        latitude: 1.00170457462,  //(57.0+23.0/60.0+36.4/3600.0) * PI / 180.0
+    };
+    let target_horizontal = calculate_target_horizontal(state.target, location, when);
+    let current_horizontal = match controller.execute(TelescopeCommand::GetDirection)? {
+        TelescopeResponse::CurrentDirection(direction) => Ok(direction),
+        _ => Err(TelescopeError::TelescopeIOError(
+            "Telescope did not respond with current direction".to_string(),
+        )),
+    }?;
+    state.current_direction = Some(current_horizontal);
+
+    match target_horizontal {
+        Some(target_horizontal) => {
+            // FIXME: How to handle static configuration like this?
+            if target_horizontal.altitude < LOWEST_ALLOWED_ALTITUDE {
+                state.most_recent_error = Some(TelescopeError::TargetBelowHorizon);
+                state.commanded_horizontal = None;
+                return Err(TelescopeError::TargetBelowHorizon);
+            }
+
+            state.commanded_horizontal = Some(target_horizontal);
+
+            // Check if more than 1 tolerance off, if so we need to send track command
+            if !directions_are_close(target_horizontal, current_horizontal, 1.0) {
+                controller.execute(TelescopeCommand::SetDirection(target_horizontal))?;
+            }
+
+            Ok(())
+        }
+        None => {
+            if state.commanded_horizontal.is_some() {
+                controller.execute(TelescopeCommand::Stop)?;
+                state.commanded_horizontal = None;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn calculate_target_horizontal(
+    target: TelescopeTarget,
+    location: Location,
+    when: DateTime<Utc>,
+) -> Option<Direction> {
+    match target {
+        TelescopeTarget::Equatorial { ra, dec } => {
+            Some(horizontal_from_equatorial(location, when, ra, dec))
+        }
+        TelescopeTarget::Galactic { l, b } => Some(horizontal_from_galactic(location, when, l, b)),
+        TelescopeTarget::Stopped => None,
+        TelescopeTarget::Parked => None,
+    }
+}
+
+fn directions_are_close(a: Direction, b: Direction, tol: f64) -> bool {
+    // The salsa telescope works with a precision of 0.1 degrees
+    // We want to send new commands whenever we exceed this tolerance
+    // but to report tracking status we allow more, so that we do not flip
+    // status between tracking/slewing (e.g. due to control unit rounding errors)
+    // Therefore we have the "tol" multiplier here, which scales the allowed error.
+    let epsilon = tol * 0.1_f64.to_radians();
+    (a.azimuth - b.azimuth).abs() < epsilon && (a.altitude - b.altitude).abs() < epsilon
+}

--- a/backend/src/telescope_tracker.rs
+++ b/backend/src/telescope_tracker.rs
@@ -52,7 +52,8 @@ impl TelescopeTracker {
             Some(current_horizontal) => current_horizontal,
             None => return Err(TelescopeError::TelescopeNotConnected),
         };
-        let status = match self.commanded_horizontal() {
+        let commanded_horizontal = self.commanded_horizontal();
+        let status = match commanded_horizontal {
             Some(commanded_horizontal) => {
                 // Check if more than 2 tolerances off, if so we are not tracking anymore
                 if directions_are_close(commanded_horizontal, current_horizontal, 2.0) {
@@ -63,12 +64,16 @@ impl TelescopeTracker {
             }
             None => TelescopeStatus::Idle,
         };
+        let (target, most_recent_error) = {
+            let lock = self.state.lock().unwrap();
+            (lock.target, lock.most_recent_error.clone())
+        };
         Ok(TelescopeTrackerInfo {
-            target: self.state.lock().unwrap().target,
+            target,
             current_horizontal,
-            commanded_horizontal: self.commanded_horizontal(),
+            commanded_horizontal,
             status,
-            most_recent_error: self.state.lock().unwrap().most_recent_error.clone(),
+            most_recent_error,
         })
     }
 


### PR DESCRIPTION
We want to achieve two things:
- Shrinking SalsaTelescope which is getting big
- More intuitive updating of telescope controller state and tracking

To do this we take out the parts relating to the telescope controller from SalsaTelescope. The SalsaTelescope remains as a facade but can in the future be broken up further.

By using a long lived task to do all communication to with one telescope controller we prepare for using less large locks in the future. Updating the telescope continuously (e.g while tracking) is moved into this task. This allows other parts of the system to send commands and observe the effects on the telescope without having to continuously drive it.