### PR TITLE
Set resolver version to 2 in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "frontend",
     "common"
 ]
+resolver = "2"
 
 [profile.dev]
 opt-level = 3 # Better optimisation for efficient FFT even in debug stage


### PR DESCRIPTION
Rust edition 2021 defaults to and requires resolver version 2. Since we use a virtual workspace for the project we don't set a Rust edition. The resolver used is determined in the workspace so we need to set the version explicitly.