### PR TITLE
Fix github workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install libuhd
-      run: sudo apt update && sudo apt-get install -y libuhd-dev
+      run: sudo apt-get update && sudo apt-get install -y libuhd-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install libuhd
-      run: sudo apt-get install -y libuhd-dev
+      run: sudo apt update && sudo apt-get install -y libuhd-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
apt-get install complained that it couldn't fetch some packages during the "Install libuhd" step. A quick apt update seems to fix that problem.