### PR TITLE
Don't run optimized builds for dev/debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,3 @@ members = [
 ]
 resolver = "2"
 
-[profile.dev]
-opt-level = 3 # Better optimisation for efficient FFT even in debug stage


### PR DESCRIPTION
If FFT is too slow then we need to find a proper solution (e.g break into own crate that is optimized or something). Always having optimized builds is too hard to debug.