### PR TITLE
Push observe url on navigation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
             <div id="logo" hx-get="/welcome.html" hx-target="#page"><a href="#">SALSA</a></div>
             <nav>
                 <menu>
-                    <li hx-get="/observe" hx-target="#page" class="list-entry">
+                    <li hx-get="/observe" hx-target="#page" hx-push-url="/observe" class="list-entry">
                         <a href="#">Observe</a>
                     </li>
                     <li hx-get="/bookings" hx-target="#page" class="list-entry">


### PR DESCRIPTION
- Push the observe url to history when navigating. Enables refresh and back button.
- Enable rendering observe inside of index template as well as as a fragment for insertion into the document by htmx.