### PR TITLE
Use full names for coordinate system components

### DIFF
--- a/src/fake_telescope.rs
+++ b/src/fake_telescope.rs
@@ -223,10 +223,14 @@ fn calculate_target_horizontal(
     current_horizontal: Direction,
 ) -> Direction {
     match target {
-        TelescopeTarget::Equatorial { ra, dec } => {
-            horizontal_from_equatorial(location, when, ra, dec)
-        }
-        TelescopeTarget::Galactic { l, b } => horizontal_from_galactic(location, when, l, b),
+        TelescopeTarget::Equatorial {
+            right_ascension: ra,
+            declination: dec,
+        } => horizontal_from_equatorial(location, when, ra, dec),
+        TelescopeTarget::Galactic {
+            longitude: l,
+            latitude: b,
+        } => horizontal_from_galactic(location, when, l, b),
         TelescopeTarget::Stopped => current_horizontal,
         TelescopeTarget::Parked => FAKE_TELESCOPE_PARKING_HORIZONTAL,
     }

--- a/src/observe_routes.rs
+++ b/src/observe_routes.rs
@@ -49,10 +49,13 @@ async fn post_observe(
     let x_rad = target.x.to_radians();
     let y_rad = target.y.to_radians();
     let target = match target.coordinate_system.as_str() {
-        "galactic" => TelescopeTarget::Galactic { l: x_rad, b: y_rad },
+        "galactic" => TelescopeTarget::Galactic {
+            longitude: x_rad,
+            latitude: y_rad,
+        },
         "equatorial" => TelescopeTarget::Equatorial {
-            ra: x_rad,
-            dec: y_rad,
+            right_ascension: x_rad,
+            declination: y_rad,
         },
         _ => return Err(TelescopeNotFound {}), // TODO: Proper errors!
     };
@@ -103,8 +106,14 @@ async fn observe(telescopes: TelescopeCollection) -> Result<String, TelescopeNot
     }
     .to_string();
     let (commanded_x, commanded_y) = match info.current_target {
-        TelescopeTarget::Equatorial { ra, dec } => (ra, dec),
-        TelescopeTarget::Galactic { l, b } => (l, b),
+        TelescopeTarget::Equatorial {
+            right_ascension: ra,
+            declination: dec,
+        } => (ra, dec),
+        TelescopeTarget::Galactic {
+            longitude: l,
+            latitude: b,
+        } => (l, b),
         _ => (
             info.current_horizontal.azimuth,
             info.current_horizontal.altitude,

--- a/src/telescope_tracker.rs
+++ b/src/telescope_tracker.rs
@@ -194,10 +194,14 @@ fn calculate_target_horizontal(
     when: DateTime<Utc>,
 ) -> Option<Direction> {
     match target {
-        TelescopeTarget::Equatorial { ra, dec } => {
-            Some(horizontal_from_equatorial(location, when, ra, dec))
-        }
-        TelescopeTarget::Galactic { l, b } => Some(horizontal_from_galactic(location, when, l, b)),
+        TelescopeTarget::Equatorial {
+            right_ascension: ra,
+            declination: dec,
+        } => Some(horizontal_from_equatorial(location, when, ra, dec)),
+        TelescopeTarget::Galactic {
+            longitude: l,
+            latitude: b,
+        } => Some(horizontal_from_galactic(location, when, l, b)),
         TelescopeTarget::Stopped => None,
         TelescopeTarget::Parked => None,
     }

--- a/src/telescopes/mod.rs
+++ b/src/telescopes/mod.rs
@@ -7,12 +7,12 @@ use std::time::Duration;
 #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
 pub enum TelescopeTarget {
     Equatorial {
-        ra: f64,  // in radians
-        dec: f64, // in radians
+        right_ascension: f64, // in radians
+        declination: f64,     // in radians
     },
     Galactic {
-        l: f64, // in radians
-        b: f64, // in radians
+        longitude: f64, // in radians
+        latitude: f64,  // in radians
     },
     Parked,
     Stopped,


### PR DESCRIPTION
Don't use abbreviations, prefer to use the full names.