### PR TITLE
Extract telescope state into it's own template

### DIFF
--- a/templates/observe.html
+++ b/templates/observe.html
@@ -42,14 +42,7 @@
       <button>Park</button>
     </p>
   </form>
-  <h2>State</h2>
-  <p>
-    Status: {{ status }}
-  </p>
-  <p>
-    Azimuth: {{ direction.azimuth.to_degrees() }}
-  </p>
-  <p>
-    Altitude: {{ direction.altitude.to_degrees() }}
-  </p>
+  <div id="state">
+    {{ state_html }}
+  </div>
 </div>

--- a/templates/telescope_state.html
+++ b/templates/telescope_state.html
@@ -1,0 +1,11 @@
+<h2>{{ info.id }}</h2>
+<p>
+  Status: {{ status }}
+</p>
+<h3>Horizontal coordinates</h3>
+<p>
+  Azimuth: {{ direction.azimuth.to_degrees() }}
+</p>
+<p>
+  Altitude: {{ direction.altitude.to_degrees() }}
+</p>


### PR DESCRIPTION
If the telescope state is it's own template it can be rendered and updated via htmx by itself. It can also be reused to show the telescope state on the welcome page.