### PR TITLE
Implement error handling in observe

### DIFF
--- a/src/observe_routes.rs
+++ b/src/observe_routes.rs
@@ -1,17 +1,21 @@
+use std::sync::Arc;
+
 use crate::index::render_main;
-use crate::telescope::TelescopeCollection;
-use crate::telescope_routes::{TelescopeNotFound, state};
-use crate::telescopes::{TelescopeInfo, TelescopeStatus, TelescopeTarget};
+use crate::telescope::{Telescope, TelescopeCollection};
+use crate::telescope_routes::state;
+use crate::telescopes::{TelescopeError, TelescopeInfo, TelescopeStatus, TelescopeTarget};
 use askama::Template;
 use axum::Form;
+use axum::body::Body;
 use axum::extract::State;
-use axum::http::HeaderMap;
-use axum::response::{Html, IntoResponse};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
 use axum::{
     Router,
     routing::{get, post},
 };
 use serde::Deserialize;
+use tokio::sync::Mutex;
 
 pub fn routes(telescopes: TelescopeCollection) -> Router {
     Router::new()
@@ -28,10 +32,49 @@ struct Target {
     coordinate_system: String,
 }
 
+enum ObserveError {
+    BadQuery(String),
+    TelescopeError(TelescopeError),
+    TelescopeNotFound(String),
+}
+
+impl IntoResponse for ObserveError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            ObserveError::BadQuery(message) => error_response(message),
+            ObserveError::TelescopeError(telescope_error) => telescope_error.into_response(),
+            ObserveError::TelescopeNotFound(id) => {
+                error_response(format!("Could not find telescope {}", id))
+            }
+        }
+    }
+}
+
+impl From<TelescopeError> for ObserveError {
+    fn from(telescope_error: TelescopeError) -> Self {
+        ObserveError::TelescopeError(telescope_error)
+    }
+}
+
+impl IntoResponse for TelescopeError {
+    fn into_response(self) -> axum::response::Response {
+        error_response(format!("{}", self))
+    }
+}
+
+fn error_response(message: String) -> Response {
+    // Create a response that will specifically update the error box on the page.
+    Response::builder()
+        .status(StatusCode::OK) // Needs to be ok to be picked up by htmx.
+        .header("HX-Retarget", "#errors")
+        .body(Body::from(message))
+        .expect("Building a response should never fail")
+}
+
 async fn post_observe(
     State(telescopes): State<TelescopeCollection>,
     Form(target): Form<Target>,
-) -> Result<impl IntoResponse, TelescopeNotFound> {
+) -> Result<impl IntoResponse, ObserveError> {
     let x_rad = target.x.to_radians();
     let y_rad = target.y.to_radians();
     let target = match target.coordinate_system.as_str() {
@@ -43,29 +86,42 @@ async fn post_observe(
             right_ascension: x_rad,
             declination: y_rad,
         },
-        _ => return Err(TelescopeNotFound {}), // TODO: Proper errors!
+        unknown => {
+            return Err(ObserveError::BadQuery(format!(
+                "Unkown coordinate system {}",
+                unknown
+            )));
+        }
     };
+
+    let telescopes_lock = telescopes.read().await;
+    let telescope = telescopes_lock
+        .get("fake")
+        .ok_or(ObserveError::TelescopeNotFound("fake".to_string()))?;
     {
-        let telescopes_lock = telescopes.read().await;
-        let telescope = telescopes_lock.get("fake").ok_or(TelescopeNotFound)?;
-        let mut telescope = telescope.telescope.clone().lock_owned().await;
+        let telescope = telescope.telescope.clone();
+        let mut telescope = telescope.lock_owned().await;
         telescope.set_target(target).await?;
     }
-    let content = observe(telescopes).await?;
-    Ok(Html(content).into_response())
+    let content = observe(telescope.telescope.clone()).await?;
+    Ok(Html(content))
 }
 
 async fn get_observe(
     State(telescopes): State<TelescopeCollection>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse, TelescopeNotFound> {
-    let content = observe(telescopes).await?;
+) -> Result<impl IntoResponse, ObserveError> {
+    let telescopes_lock = telescopes.read().await;
+    let telescope = telescopes_lock
+        .get("fake")
+        .ok_or(ObserveError::TelescopeNotFound("fake".to_string()))?;
+    let content = observe(telescope.telescope.clone()).await?;
     let content = if headers.get("hx-request").is_some() {
         content
     } else {
         render_main(content)
     };
-    Ok(Html(content).into_response())
+    Ok(Html(content))
 }
 
 #[derive(Template)]
@@ -79,13 +135,11 @@ struct ObserveTemplate {
     state_html: String,
 }
 
-async fn observe(telescopes: TelescopeCollection) -> Result<String, TelescopeNotFound> {
+async fn observe(telescope: Arc<Mutex<dyn Telescope>>) -> Result<String, TelescopeError> {
     // We have to be a little careful about the locking.
-    let telescopes_lock = telescopes.read().await;
-    let telescope = telescopes_lock.get("fake").ok_or(TelescopeNotFound)?;
     // First extract all data needed for the primary template.
     let (info, status, target_mode, commanded_x, commanded_y) = {
-        let telescope = telescope.telescope.clone().lock_owned().await;
+        let telescope = telescope.clone().lock_owned().await;
         let info = telescope.get_info().await?;
         let target_mode = match &info.current_target {
             TelescopeTarget::Equatorial { .. } => "equatorial",

--- a/templates/observe.html
+++ b/templates/observe.html
@@ -3,6 +3,8 @@
   <p>
     Telescope: {{ info.id }}
   </p>
+  <div id="errors">
+  </div>
   <h2>Target</h2>
   <form>
     <p>


### PR DESCRIPTION
Put a div on the page and put any errors into the div.

It will not quite work if no page with an error box has ever been rendered. This will require some further reworking.

Part of the error handling here could be extracted to deal with errors that occur elsewhere.