### PR TITLE
Hide telescope collection locks from client

### DIFF
--- a/src/telescope_routes.rs
+++ b/src/telescope_routes.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::coords::Direction;
-use crate::telescope::{Telescope, TelescopeCollection};
+use crate::telescope::{Telescope, TelescopeCollectionHandle};
 use crate::telescopes::{ReceiverConfiguration, ReceiverError, TelescopeStatus};
 use crate::telescopes::{TelescopeError, TelescopeInfo, TelescopeTarget};
 use askama::Template;
@@ -15,7 +15,7 @@ use axum::{
 };
 use tokio::sync::Mutex;
 
-pub fn routes(telescopes: TelescopeCollection) -> Router {
+pub fn routes(telescopes: TelescopeCollectionHandle) -> Router {
     let telescope_routes = Router::new()
         .route("/", get(get_telescope))
         .route("/direction", get(get_direction))
@@ -29,9 +29,11 @@ pub fn routes(telescopes: TelescopeCollection) -> Router {
         .with_state(telescopes)
 }
 
-async fn get_telescopes(State(telescopes): State<TelescopeCollection>) -> Json<Vec<TelescopeInfo>> {
+async fn get_telescopes(
+    State(telescopes): State<TelescopeCollectionHandle>,
+) -> Json<Vec<TelescopeInfo>> {
     let mut telescope_infos = Vec::<TelescopeInfo>::new();
-    for (name, telescope) in telescopes.read().await.iter() {
+    for (name, telescope) in telescopes.all().await.iter() {
         log::trace!("Checking {}", name);
         let telescope = telescope.telescope.lock().await;
         if let Ok(info) = telescope.get_info().await {
@@ -61,16 +63,15 @@ impl From<TelescopeError> for TelescopeNotFound {
 }
 
 async fn extract_telescope(
-    telescopes: TelescopeCollection,
+    telescopes: TelescopeCollectionHandle,
     id: String,
 ) -> Result<tokio::sync::OwnedMutexGuard<dyn Telescope>, TelescopeNotFound> {
-    let telescpes = telescopes.read().await;
-    let telescope = telescpes.get(&id).ok_or(TelescopeNotFound)?;
+    let telescope = telescopes.get(&id).await.ok_or(TelescopeNotFound)?;
     Ok(telescope.telescope.clone().lock_owned().await)
 }
 
 async fn get_telescope(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
 ) -> Result<Json<Result<TelescopeInfo, TelescopeError>>, TelescopeNotFound> {
     let telescope = extract_telescope(telescopes, telescope_id).await?;
@@ -78,7 +79,7 @@ async fn get_telescope(
 }
 
 async fn get_direction(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
 ) -> Result<Json<Result<Direction, TelescopeError>>, TelescopeNotFound> {
     let telescope = extract_telescope(telescopes, telescope_id).await?;
@@ -86,7 +87,7 @@ async fn get_direction(
 }
 
 async fn get_target(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
 ) -> Result<Json<Result<TelescopeTarget, TelescopeError>>, TelescopeNotFound> {
     let telescope = extract_telescope(telescopes, telescope_id).await?;
@@ -94,7 +95,7 @@ async fn get_target(
 }
 
 async fn set_target(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
     Json(target): Json<TelescopeTarget>,
 ) -> Result<Json<Result<TelescopeTarget, TelescopeError>>, TelescopeNotFound> {
@@ -103,7 +104,7 @@ async fn set_target(
 }
 
 async fn restart(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
 ) -> Result<Json<Result<(), TelescopeError>>, TelescopeNotFound> {
     let mut telescope = extract_telescope(telescopes, telescope_id).await?;
@@ -111,7 +112,7 @@ async fn restart(
 }
 
 async fn set_receiver_configuration(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
     Json(target): Json<ReceiverConfiguration>,
 ) -> Result<Json<Result<ReceiverConfiguration, ReceiverError>>, TelescopeNotFound> {
@@ -120,12 +121,12 @@ async fn set_receiver_configuration(
 }
 
 pub async fn get_state(
-    State(telescopes): State<TelescopeCollection>,
+    State(telescopes): State<TelescopeCollectionHandle>,
     Path(telescope_id): Path<String>,
 ) -> Result<impl IntoResponse, TelescopeNotFound> {
-    let telescopes_lock = telescopes.read().await;
-    let telescope = telescopes_lock
+    let telescope = telescopes
         .get(&telescope_id)
+        .await
         .ok_or(TelescopeNotFound)?;
     Ok(Html(state(telescope.telescope.clone()).await?))
 }


### PR DESCRIPTION
Easier to just use an async API through an owned handle to an underlying telescope collection.