### PR TITLE
Remove tracking toggle from observe

### DIFF
--- a/templates/observe.html
+++ b/templates/observe.html
@@ -34,10 +34,6 @@
     </p>
 
     <p>
-      <label for="track">Track</label>
-      <input type="checkbox" name="track" {% if status == "Tracking" %}checked{% endif %}>
-    </p>
-    <p>
       <button hx-post="/observe" hx-target="#page">Go!</button>
     </p>
     <p>


### PR DESCRIPTION
It wasn't working. Let's do tracking by default. If the user wants to stop tracking they can press park (although park isn't implemented yet).