### PR TITLE
Remove make booking and weather from navbar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,12 +22,6 @@
                     <li hx-get="/bookings" hx-target="#page" hx-push-url="/bookings" class="list-entry">
                         <a href="#">Bookings</a>
                     </li>
-                    <li hx-get="/make_booking.html" hx-target="#page" class="list-entry">
-                        <a href="#">Make booking</a>
-                    </li>
-                    <li hx-get="/weather.html" hx-target="#page" class="list-entry">
-                        <a href="#">Weather</a>
-                    </li>
                 </menu>
             </nav>
             <nav>


### PR DESCRIPTION
We don't need a separate make booking now so let's remove it.

We also don't need weather on the navbar.