### PR TITLE
Add start and stop backend test

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,17 @@
+use std::process::Command;
+
+#[test]
+fn can_start_and_stop_backend() {
+    let backend_executable = env!("CARGO_BIN_EXE_backend");
+    println!("Running `backend` {backend_executable}");
+    let mut process = Command::new(backend_executable)
+        .spawn()
+        .expect("Could not start backend");
+
+    Command::new("kill")
+        .args(["-s", "TERM", &process.id().to_string()])
+        .status()
+        .expect("Failed to send signal");
+
+    process.wait().expect("backend failed to stop");
+}


### PR DESCRIPTION
The code demonstrates how to run a binary in a test as well as how to shut it down.

This test is mostly a placeholder and a start for further tests.