### PR TITLE
Set telescope to observe through from path

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,21 +2,22 @@
 <html lang="en">
     <head>
         <title>SALSA</title>
-        <link rel="stylesheet" href="style.css" />
+        <link rel="stylesheet" href="/style.css" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Roboto+Flex:opsz,wght@8..144,300;8..144,400&display=swap" rel="stylesheet">
         <meta charset='UTF-8'/>
         <meta name='viewport'
         content='width=device-width, initial-scale=1.0, maximum-scale=1.0' />
-        <script src="https://unpkg.com/htmx.org@2.0.0"></script>
+        <!-- <script src="https://unpkg.com/htmx.org@2.0.0"></script> -->
+        <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.js" integrity="sha384-oeUn82QNXPuVkGCkcrInrS1twIxKhkZiFfr2TdiuObZ3n3yIeMiqcRzkIcguaof1" crossorigin="anonymous"></script>
     </head>
     <body>
         <header>
             <div id="logo" hx-get="/welcome.html" hx-push-url="/" hx-target="#page"><a href="#">SALSA</a></div>
             <nav>
                 <menu>
-                    <li hx-get="/observe" hx-target="#page" hx-push-url="/observe" class="list-entry">
+                    <li hx-get="/observe/fake" hx-target="#page" hx-push-url="/observe/fake" class="list-entry">
                         <a href="#">Observe</a>
                     </li>
                     <li hx-get="/bookings" hx-target="#page" hx-push-url="/bookings" class="list-entry">

--- a/templates/observe.html
+++ b/templates/observe.html
@@ -40,13 +40,13 @@
     </p>
 
     <p>
-      <button hx-post="/observe" hx-target="#page" name="action" value="go">Go!</button>
+      <button hx-post="#" hx-target="#page" name="action" value="go">Go!</button>
     </p>
     <p>
-      <button hx-post="/observe" hx-target="#page" name="action" value="park">Park</button>
+      <button hx-post="#" hx-target="#page" name="action" value="park">Park</button>
     </p>
   </form>
-  <div id="state" hx-get="telescope/{{ info.id }}/state" hx-trigger="every 1s">
+  <div id="state" hx-get="/telescope/{{ info.id }}/state" hx-trigger="every 1s">
     {{ state_html }}
   </div>
 </div>


### PR DESCRIPTION
Use `observe/<telescope id>` to select which telescope to use for observation. This required some random updates to not break other things.

The _Observe_ link in the navbar is now pointed to `observe/fake` to keep the same behavior. Other telescopes are only available through changing the path directly in the browser.