### PR TITLE
Add debug log for measurement websocket

### DIFF
--- a/src/telescope_routes.rs
+++ b/src/telescope_routes.rs
@@ -41,6 +41,7 @@ async fn spectrum_handle_upgrade(
         .ok_or(TelescopeNotFound)?;
     // WebSockets come in as a regular HTTP request, that connection is then
     // upgraded to a socket.
+    log::debug!("Setting up measurement websocket for {}", telescope_id);
     Ok(upgrade.on_upgrade(move |socket| spectrum_handle_websocket(socket, telescope)))
 }
 


### PR DESCRIPTION
Helpful to get some info about what's going on the backend for debugging purposes.