### PR TITLE
Fix measurement websocket to wrong telescope

### DIFF
--- a/assets/observe_chart.js
+++ b/assets/observe_chart.js
@@ -1,3 +1,12 @@
+function get_telescope_from_location() {
+  const path_parts = window.location.pathname.split('/')
+  // Loop to one less to allow picking an item one ahead of i.
+  for (let i = 0; i < path_parts.length - 1; i++) {
+    if (path_parts[i] == "observe") return path_parts[i + 1];
+  }
+  throw Error("Failed to find a telescope from the URL path");
+}
+
 (function () {
   const width = 800;
   const height = 600;
@@ -56,7 +65,7 @@
   if (window.spectrumSocket) {
     window.spectrumSocket.close();
   }
-  window.spectrumSocket = new WebSocket("/telescope/fake/spectrum");
+  window.spectrumSocket = new WebSocket(`/telescope/${get_telescope_from_location()}/spectrum`);
   window.spectrumSocket.onmessage = async (event) => {
     let dataView = new DataView(await event.data.arrayBuffer());
     let data = [];

--- a/development/database.json
+++ b/development/database.json
@@ -33,7 +33,23 @@
     ],
     "telescopes": [
         {
-            "name": "fake",
+            "name": "fake1",
+            "enabled": true,
+            "location": {
+                "longitude": 0.20802143022,
+                "latitude": 1.00170457462
+            },
+            "min_elevation": 0.087,
+            "telescope_type": {
+                "Fake": {
+                    "definition": {
+                        "slewing_speed": 0.314
+                    }
+                }
+            }
+        },
+        {
+            "name": "fake2",
             "enabled": true,
             "location": {
                 "longitude": 0.20802143022,


### PR DESCRIPTION
The measurement websocket URL is extracted from the current window.location instead of hardcoding to `fake`. This makes it possible to observe a spectrum with a real telescope.

Also change `fake` to two fake telescopes: `fake1` and `fake2`. Having two different ones is helpful for testing out telescope selection logic.