### PR TITLE
Deploy only on merge to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,7 @@ jobs:
   deploy:
     needs: build
     runs-on: salsa
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/download-artifact@v5


### PR DESCRIPTION
We don't want to deploy PRs to production before they are merged.

Solves #226.