### PR TITLE
Only allow one instance of deploy to run at a time

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,10 @@ jobs:
     runs-on: salsa
     if: github.ref == 'refs/heads/main'
 
+    concurrency:
+      group: deploy-main
+      cancel-in-progress: false
+
     steps:
       - uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
Avoid deployment races between concurrent jobs. We want to know that the latest commit is deployed at any time.