### PR TITLE
Clear previous observation data when starting a new integration

### DIFF
--- a/src/models/fake_telescope.rs
+++ b/src/models/fake_telescope.rs
@@ -118,6 +118,7 @@ impl Telescope for FakeTelescope {
 
         if receiver_configuration.integrate && !inner.receiver_configuration.integrate {
             log::info!("Starting integration");
+            inner.current_spectra.clear();
             inner.receiver_configuration.integrate = true;
         } else if !receiver_configuration.integrate && inner.receiver_configuration.integrate {
             log::info!("Stopping integration");

--- a/src/models/salsa_telescope.rs
+++ b/src/models/salsa_telescope.rs
@@ -92,6 +92,7 @@ impl Telescope for SalsaTelescope {
 
             log::info!("Starting integration");
             inner.receiver_configuration.integrate = true;
+            inner.measurements.lock().await.clear();
             let cancellation_token = CancellationToken::new();
             let measurement_task = {
                 let address = inner.receiver_address.clone();


### PR DESCRIPTION
## Summary

- When stopping and restarting an observation, the accumulated spectra from the previous run were not cleared
- This caused the second observation to show combined data from both runs and report an incorrect integration time
- Fixed by calling `.clear()` on `current_spectra` (fake telescope) and `measurements` (SALSA telescope) when integration transitions from `false` to `true`

## Test plan

- [ ] Start an observation, let it accumulate some data
- [ ] Stop the observation
- [ ] Start a new observation — verify the spectrum resets to fresh data
- [ ] Verify the integration time shown starts from zero on the new observation

🤖 Generated with [Claude Code](https://claude.com/claude-code)