### PR TITLE
Observations list: pagination and delete

### DIFF
--- a/assets/observation_chart.js
+++ b/assets/observation_chart.js
@@ -20,15 +20,22 @@ function loadObservation(id) {
       return res.json();
     })
     .then((data) => {
-      // Highlight selected observation row
+      // Highlight selected observation row, show only its delete button
       document.querySelectorAll("[id^='obs-row-']").forEach((el) => {
         el.classList.remove("bg-indigo-50", "border-indigo-300");
         el.classList.add("border-transparent");
+      });
+      document.querySelectorAll("[id^='del-btn-']").forEach((el) => {
+        el.classList.add("hidden");
       });
       const selectedRow = document.getElementById(`obs-row-${id}`);
       if (selectedRow) {
         selectedRow.classList.remove("border-transparent");
         selectedRow.classList.add("bg-indigo-50", "border-indigo-300");
+      }
+      const delBtn = document.getElementById(`del-btn-${id}`);
+      if (delBtn) {
+        delBtn.classList.remove("hidden");
       }
 
       const container = document.getElementById("observation-chart");

--- a/src/models/observation.rs
+++ b/src/models/observation.rs
@@ -118,6 +118,20 @@ impl Observation {
         .map_err(|err| InternalError::new(format!("Failed to count observations: {err}")))
     }
 
+    pub async fn delete(
+        connection: Arc<Mutex<Connection>>,
+        id: i64,
+        user: &User,
+    ) -> Result<(), InternalError> {
+        let conn = connection.lock().await;
+        conn.execute(
+            "DELETE FROM observation WHERE id = (?1) AND user_id = (?2)",
+            [&id, &user.id],
+        )
+        .map_err(|err| InternalError::new(format!("Failed to delete observation: {err}")))?;
+        Ok(())
+    }
+
     pub async fn fetch_one(
         connection: Arc<Mutex<Connection>>,
         id: i64,

--- a/src/routes/observations.rs
+++ b/src/routes/observations.rs
@@ -14,7 +14,10 @@ const PAGE_SIZE: i64 = 10;
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/", get(get_observations))
-        .route("/{observation_id}", get(get_observation_data))
+        .route(
+            "/{observation_id}",
+            get(get_observation_data).delete(delete_observation),
+        )
         .with_state(state)
 }
 
@@ -34,6 +37,33 @@ struct ObservationsTemplate {
     total_count: i64,
 }
 
+fn build_observations_template(
+    observations: Vec<Observation>,
+    total_count: i64,
+    current_page: usize,
+) -> ObservationsTemplate {
+    let total_pages = ((total_count as usize).saturating_sub(1) / PAGE_SIZE as usize) + 1;
+    let current_page = current_page.min(total_pages.max(1));
+    let prev_page = if current_page > 1 {
+        Some(current_page - 1)
+    } else {
+        None
+    };
+    let next_page = if current_page < total_pages {
+        Some(current_page + 1)
+    } else {
+        None
+    };
+    ObservationsTemplate {
+        observations,
+        current_page,
+        total_pages,
+        prev_page,
+        next_page,
+        total_count,
+    }
+}
+
 async fn get_observations(
     Extension(user): Extension<Option<User>>,
     headers: HeaderMap,
@@ -49,31 +79,36 @@ async fn get_observations(
     let observations =
         Observation::fetch_for_user_page(state.database_connection, &user, PAGE_SIZE, offset)
             .await?;
-    let prev_page = if current_page > 1 {
-        Some(current_page - 1)
-    } else {
-        None
-    };
-    let next_page = if current_page < total_pages {
-        Some(current_page + 1)
-    } else {
-        None
-    };
-    let content = ObservationsTemplate {
-        observations,
-        current_page,
-        total_pages,
-        prev_page,
-        next_page,
-        total_count,
-    }
-    .render()
-    .expect("Template rendering should always succeed");
+    let content = build_observations_template(observations, total_count, current_page)
+        .render()
+        .expect("Template rendering should always succeed");
     let content = if headers.get("hx-request").is_some() {
         content
     } else {
         render_main(Some(user), content)
     };
+    Ok(Html(content).into_response())
+}
+
+async fn delete_observation(
+    Extension(user): Extension<Option<User>>,
+    Path(observation_id): Path<i64>,
+    Query(query): Query<PageQuery>,
+    State(state): State<AppState>,
+) -> Result<Response, StatusCode> {
+    let user = user.ok_or(StatusCode::UNAUTHORIZED)?;
+    Observation::delete(state.database_connection.clone(), observation_id, &user).await?;
+    let current_page = query.page.unwrap_or(1).max(1);
+    let total_count = Observation::count_for_user(state.database_connection.clone(), &user).await?;
+    let total_pages = ((total_count as usize).saturating_sub(1) / PAGE_SIZE as usize) + 1;
+    let current_page = current_page.min(total_pages.max(1));
+    let offset = ((current_page - 1) as i64) * PAGE_SIZE;
+    let observations =
+        Observation::fetch_for_user_page(state.database_connection, &user, PAGE_SIZE, offset)
+            .await?;
+    let content = build_observations_template(observations, total_count, current_page)
+        .render()
+        .expect("Template rendering should always succeed");
     Ok(Html(content).into_response())
 }
 

--- a/templates/observations.html
+++ b/templates/observations.html
@@ -6,18 +6,26 @@
   <div class="flex flex-col lg:flex-row gap-4">
     <div class="lg:w-1/3">
       <h2 class="mt-4 mb-3">My observations</h2>
-      <p class="text-xs text-gray-400 mb-2">{{ total_count }} observations · click to view spectrum</p>
+      <p class="text-xs text-gray-400 mb-2">{{ total_count }} observations · click to view spectrum · ✕ to delete selected</p>
       <div class="space-y-1">
           {% for obs in observations %}
           <div
             id="obs-row-{{ obs.id }}"
-            class="cursor-pointer hover:bg-gray-100 p-2 rounded border border-transparent text-sm"
-            onclick="loadObservation({{ obs.id }})"
+            class="hover:bg-gray-100 p-2 rounded border border-transparent text-sm flex justify-between items-center"
           >
-            {{ obs.start_time.naive_local() }} &mdash;
-            {{ obs.telescope_id }},
-            {{ obs.coordinate_system }} ({{ obs.target_x|fmt("{:.1}") }}, {{ obs.target_y|fmt("{:.1}") }}),
-            {{ obs.integration_time_secs|fmt("{:.0}") }}s
+            <span class="cursor-pointer" onclick="loadObservation({{ obs.id }})">
+              {{ obs.start_time.naive_local() }} &mdash;
+              {{ obs.telescope_id }},
+              {{ obs.coordinate_system }} ({{ obs.target_x|fmt("{:.1}") }}, {{ obs.target_y|fmt("{:.1}") }}),
+              {{ obs.integration_time_secs|fmt("{:.0}") }}s
+            </span>
+            <button
+              id="del-btn-{{ obs.id }}"
+              class="ml-2 text-gray-400 hover:text-red-500 text-xs px-1 flex-shrink-0 hidden"
+              hx-delete="/observations/{{ obs.id }}?page={{ current_page }}"
+              hx-target="#page"
+              hx-confirm="Delete this observation?"
+            >✕</button>
           </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
## Summary

- Replaces the scrollable observations list (with broken fade gradient) with server-side pagination, 10 per page, using HTMX partial updates
- Adds a delete button per observation, visible only on the currently selected row, with a browser confirm dialog before deletion

## Changes

- `src/models/observation.rs`: added `fetch_for_user_page` (LIMIT/OFFSET), `count_for_user`, and `delete` model methods; removed unused `fetch_for_user`
- `src/routes/observations.rs`: added `PageQuery`, pagination logic, and `delete_observation` handler
- `templates/observations.html`: paginated list with Prev/Next nav; ✕ delete button (hidden by default); updated hint text
- `assets/observation_chart.js`: show ✕ button only for the selected row, hide all others on selection change

## Test plan

- [ ] Fewer than 10 observations: no pagination nav shown
- [ ] More than 10 observations: Prev/Next buttons appear and navigate correctly
- [ ] HTMX partial update on pagination (no full page reload)
- [ ] Click an observation row — ✕ button appears only on that row
- [ ] Click ✕ — confirm dialog appears; cancel keeps the observation, confirm deletes it and refreshes the list
- [ ] Deleting the last item on a page navigates back to the previous page

🤖 Generated with [Claude Code](https://claude.com/claude-code)