### PR TITLE
Redirect unauthenticated users to login

### DIFF
--- a/src/routes/booking.rs
+++ b/src/routes/booking.rs
@@ -6,7 +6,7 @@ use crate::routes::index::render_main;
 use askama::Template;
 use axum::extract::{Path, Query};
 use axum::http::HeaderMap;
-use axum::response::{Html, IntoResponse, Response};
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::{Extension, Form};
 use axum::{
     Router,
@@ -141,7 +141,11 @@ async fn get_bookings(
     State(state): State<AppState>,
 ) -> Result<Response, StatusCode> {
     let Some(user) = user else {
-        return Ok(StatusCode::UNAUTHORIZED.into_response());
+        return Ok(if headers.get("hx-request").is_some() {
+            ([("HX-Redirect", "/auth/login")], "").into_response()
+        } else {
+            Redirect::to("/auth/login").into_response()
+        });
     };
 
     let viewed_user_id = if user.is_admin {

--- a/src/routes/observations.rs
+++ b/src/routes/observations.rs
@@ -7,7 +7,7 @@ use askama::Template;
 use axum::extract::{Path, Query, State};
 use axum::http::header;
 use axum::http::{HeaderMap, StatusCode};
-use axum::response::{Html, IntoResponse, Json, Response};
+use axum::response::{Html, IntoResponse, Json, Redirect, Response};
 use axum::{Extension, Router, routing::get};
 use serde::{Deserialize, Serialize};
 
@@ -84,7 +84,13 @@ async fn get_observations(
     Query(query): Query<PageQuery>,
     State(state): State<AppState>,
 ) -> Result<Response, StatusCode> {
-    let user = user.ok_or(StatusCode::UNAUTHORIZED)?;
+    let Some(user) = user else {
+        return Ok(if headers.get("hx-request").is_some() {
+            ([("HX-Redirect", "/auth/login")], "").into_response()
+        } else {
+            Redirect::to("/auth/login").into_response()
+        });
+    };
     let viewed_user_id = if user.is_admin {
         query.user_id.unwrap_or(user.id)
     } else {


### PR DESCRIPTION
## Summary

Visiting `/bookings` or `/observations` while logged out previously returned a blank 401 response. Now redirects to `/auth/login` instead. HTMX requests use `HX-Redirect` to trigger a full-page navigation rather than loading the login page into `#page`.

## Test plan

- [ ] Visit `/bookings` while logged out — should redirect to login page
- [ ] Visit `/observations` while logged out — should redirect to login page
- [ ] Clicking nav links while logged out should navigate to login cleanly, no double navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)