### PR TITLE
Show telescope controller connectivity to users and admins

### DIFF
--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use crate::app::AppState;
 use crate::models::booking::Booking;
 use crate::models::maintenance::{fetch_maintenance_set, set_maintenance};
+use crate::models::telescope_types::TelescopeError;
 use crate::models::user::User;
 use crate::routes::index::render_main;
 
@@ -34,7 +35,7 @@ fn require_admin(user: Option<User>) -> Result<User, StatusCode> {
 #[derive(Template)]
 #[template(path = "admin.html", escape = "none")]
 struct AdminTemplate {
-    telescopes: Vec<(String, bool, bool)>, // (name, in_maintenance, is_booked_now)
+    telescopes: Vec<(String, bool, bool, bool)>, // (name, in_maintenance, is_booked_now, is_connected)
     usage_from: NaiveDate,
     usage_to: NaiveDate,
     total_bookings: usize,
@@ -64,14 +65,24 @@ async fn get_admin(
     let active_bookings = Booking::fetch_active(state.database_connection.clone())
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let telescopes = telescope_names
-        .into_iter()
-        .map(|name| {
-            let in_maintenance = maintenance.contains(&name);
-            let is_booked_now = active_bookings.iter().any(|b| b.telescope_name == name);
-            (name, in_maintenance, is_booked_now)
-        })
-        .collect();
+    let mut telescopes = Vec::new();
+    for name in telescope_names {
+        let in_maintenance = maintenance.contains(&name);
+        let is_booked_now = active_bookings.iter().any(|b| b.telescope_name == name);
+        let is_connected = if let Some(tel) = state.telescopes.get(&name).await {
+            tel.get_info().await.is_ok_and(|i| {
+                !matches!(
+                    i.most_recent_error,
+                    Some(
+                        TelescopeError::TelescopeIOError(_) | TelescopeError::TelescopeNotConnected
+                    )
+                )
+            })
+        } else {
+            false
+        };
+        telescopes.push((name, in_maintenance, is_booked_now, is_connected));
+    }
 
     let bookings = Booking::fetch_in_range(state.database_connection, from_dt, to_dt)
         .await

--- a/src/routes/observe.rs
+++ b/src/routes/observe.rs
@@ -580,10 +580,7 @@ async fn observe(telescope: &dyn Telescope, in_maintenance: bool) -> Result<Stri
         ),
         None => (String::new(), String::new()),
     };
-    let state_html = telescope_state(telescope).await.map_err(|err| {
-        error!("Failed to get telescope state {err}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let state_html = telescope_state(&info.id, telescope).await;
     Ok(ObserveTemplate {
         info,
         target_mode,

--- a/src/routes/telescope.rs
+++ b/src/routes/telescope.rs
@@ -115,13 +115,6 @@ impl IntoResponse for TelescopeNotFound {
     }
 }
 
-// HACK: Hacky hack!
-impl From<TelescopeError> for TelescopeNotFound {
-    fn from(_: TelescopeError) -> Self {
-        TelescopeNotFound {}
-    }
-}
-
 pub async fn get_state(
     State(state): State<AppState>,
     Path(telescope_id): Path<String>,
@@ -131,7 +124,9 @@ pub async fn get_state(
         .get(&telescope_id)
         .await
         .ok_or(TelescopeNotFound)?;
-    Ok(Html(telescope_state(telescope.as_ref()).await?))
+    Ok(Html(
+        telescope_state(&telescope_id, telescope.as_ref()).await,
+    ))
 }
 
 #[derive(Template)]
@@ -142,26 +137,52 @@ struct TelescopeStateTemplate {
     error: String,
 }
 
-pub async fn telescope_state(telescope: &dyn Telescope) -> Result<String, TelescopeError> {
-    let info = telescope.get_info().await?;
-    Ok(TelescopeStateTemplate {
-        info: info.clone(),
-        status: match &info.status {
-            TelescopeStatus::Idle => "Idle".to_string(),
-            TelescopeStatus::Slewing => "Slewing".to_string(),
-            TelescopeStatus::Tracking => "Tracking".to_string(),
-        },
-        error: match &info.most_recent_error {
-            Some(err) => match err {
-                TelescopeError::TargetBelowHorizon => "target is below horizon".to_string(),
-                TelescopeError::TelescopeIOError(_) => {
-                    "io error in communication with telescope".to_string()
-                }
-                TelescopeError::TelescopeNotConnected => "telescope is not connected".to_string(),
+#[derive(Template)]
+#[template(path = "telescope_state_offline.html")]
+struct TelescopeOfflineTemplate {
+    id: String,
+}
+
+pub async fn telescope_state(telescope_id: &str, telescope: &dyn Telescope) -> String {
+    match telescope.get_info().await {
+        Ok(info)
+            if matches!(
+                info.most_recent_error,
+                Some(TelescopeError::TelescopeIOError(_) | TelescopeError::TelescopeNotConnected)
+            ) =>
+        {
+            TelescopeOfflineTemplate {
+                id: telescope_id.to_string(),
+            }
+            .render()
+            .expect("Template rendering should always succeed")
+        }
+        Ok(info) => TelescopeStateTemplate {
+            info: info.clone(),
+            status: match &info.status {
+                TelescopeStatus::Idle => "Idle".to_string(),
+                TelescopeStatus::Slewing => "Slewing".to_string(),
+                TelescopeStatus::Tracking => "Tracking".to_string(),
             },
-            None => "".to_string(),
-        },
+            error: match &info.most_recent_error {
+                Some(err) => match err {
+                    TelescopeError::TargetBelowHorizon => "target is below horizon".to_string(),
+                    TelescopeError::TelescopeIOError(_) => {
+                        "io error in communication with telescope".to_string()
+                    }
+                    TelescopeError::TelescopeNotConnected => {
+                        "telescope is not connected".to_string()
+                    }
+                },
+                None => "".to_string(),
+            },
+        }
+        .render()
+        .expect("Template rendering should always succeed"),
+        Err(_) => TelescopeOfflineTemplate {
+            id: telescope_id.to_string(),
+        }
+        .render()
+        .expect("Template rendering should always succeed"),
     }
-    .render()
-    .expect("Template rendering should always succeed"))
 }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -12,15 +12,23 @@
     <thead>
       <tr class="text-left text-gray-500 border-b">
         <th class="pb-2 pr-8">Telescope</th>
+        <th class="pb-2 pr-8">Controller</th>
         <th class="pb-2 pr-8">Status</th>
         <th class="pb-2 pr-8">Current slot</th>
         <th class="pb-2"></th>
       </tr>
     </thead>
     <tbody>
-      {% for (name, in_maintenance, is_booked_now) in telescopes %}
+      {% for (name, in_maintenance, is_booked_now, is_connected) in telescopes %}
       <tr class="border-b last:border-0">
         <td class="py-2 pr-8 font-medium">{{ name }}</td>
+        <td class="py-2 pr-8">
+          {% if is_connected %}
+          <span class="text-green-700">Online</span>
+          {% else %}
+          <span class="text-red-600 font-semibold">Offline</span>
+          {% endif %}
+        </td>
         <td class="py-2 pr-8">
           {% if in_maintenance %}
           <span class="text-yellow-700 font-semibold">Maintenance</span>

--- a/templates/telescope_state_offline.html
+++ b/templates/telescope_state_offline.html
@@ -1,0 +1,6 @@
+<span id="measuring-state" data-measuring="false" data-obs-secs="0" class="hidden"></span>
+
+<h2 class="font-semibold mb-3">Telescope &mdash; {{ id }} &mdash;
+  <span class="text-red-600">Offline</span>
+</h2>
+<p class="text-red-600 text-sm mb-2">Cannot connect to telescope controller.</p>


### PR DESCRIPTION
## Summary

- When a telescope controller is unreachable, the observe page status area (polled every 1s) now shows an **Offline** banner instead of silently freezing
- The admin telescope table gains a **Controller** column showing Online/Offline for each telescope

Connectivity is derived from `most_recent_error` in the cached tracker state — no extra network calls needed. A `TelescopeIOError` or `TelescopeNotConnected` error marks the telescope offline; cleared automatically when the controller reconnects.

Closes #232

## Test plan
- [ ] With controller reachable: observe page shows normal status, admin shows Online
- [ ] With controller unreachable: observe page status area shows "Offline" banner within ~1s, admin shows Offline in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)