### PR TITLE
Redirect HTTP to HTTPS (issue #220)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
-use axum::extract::MatchedPath;
-use axum::http::Request;
+use axum::extract::{MatchedPath, State};
+use axum::http::{HeaderMap, Request, Uri};
 use axum::middleware;
+use axum::response::{IntoResponse, Redirect, Response};
 use axum::{Router, routing::get};
 use rusqlite::Connection;
 use std::path::Path;
@@ -139,4 +140,28 @@ pub async fn teardown_app(app: AppState) {
     for telescope in app.telescopes.get_all().await {
         telescope.shutdown().await;
     }
+}
+
+pub fn create_redirect_app(https_port: u16) -> Router {
+    Router::new()
+        .fallback(redirect_to_https)
+        .with_state(https_port)
+}
+
+async fn redirect_to_https(
+    uri: Uri,
+    State(https_port): State<u16>,
+    headers: HeaderMap,
+) -> Response {
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let hostname = host.split(':').next().unwrap_or(host);
+    let https_url = if https_port == 443 {
+        format!("https://{hostname}{uri}")
+    } else {
+        format!("https://{hostname}:{https_port}{uri}")
+    };
+    Redirect::permanent(&https_url).into_response()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,22 @@ async fn main() {
         let tls_config = RustlsConfig::from_pem_file(cert_file_path, key_file_path)
             .await
             .unwrap();
+
+        let https_port = addr.port();
+        let redirect_listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], 80))).unwrap();
+        log::info!("listening for HTTP->HTTPS redirect on port 80");
+        let redirect_app = app::create_redirect_app(https_port);
+        let redirect_handle = handle.clone();
+        tokio::spawn(async move {
+            if let Err(e) = axum_server::from_tcp(redirect_listener)
+                .handle(redirect_handle)
+                .serve(redirect_app.into_make_service())
+                .await
+            {
+                log::error!("HTTP redirect server error: {e}");
+            }
+        });
+
         axum_server::from_tcp_rustls(listener, tls_config)
             .handle(handle)
             .serve(app.into_make_service())


### PR DESCRIPTION
## Summary
- When TLS is configured, spawns a second server on port 80 that issues permanent (308) redirects to the HTTPS equivalent URL
- Shares the shutdown handle so both servers stop together gracefully
- No redirect in local dev (only active when `--key-file-path` is provided)

## Notes
- Port 80 requires `CAP_NET_BIND_SERVICE` or root on Linux — same as the existing port 443 binding
- Redirect correctly handles non-443 HTTPS ports by appending the port to the URL

Closes #220

## Test plan
- [ ] Hit `http://<host>` on live machine and verify redirect to `https://<host>`
- [ ] Verify local dev (no TLS args) still works as plain HTTP with no redirect server

🤖 Generated with [Claude Code](https://claude.com/claude-code)