### PR TITLE
Fix GNSS satellite selection lost on page navigation

### DIFF
--- a/src/routes/observe.rs
+++ b/src/routes/observe.rs
@@ -823,9 +823,8 @@ async fn observe(
             fmt_deg(azimuth.to_degrees()),
             fmt_deg(elevation.to_degrees()),
         ),
-        Some(TelescopeTarget::Sun) | Some(TelescopeTarget::Satellite { .. }) | None => {
-            (String::new(), String::new())
-        }
+        Some(TelescopeTarget::Satellite { norad_id }) => (norad_id.to_string(), String::new()),
+        Some(TelescopeTarget::Sun) | None => (String::new(), String::new()),
     };
     let state_html = telescope_state(&info.id, telescope).await;
     let (freq_min_mhz, freq_max_mhz) = if is_admin {

--- a/templates/observe.html
+++ b/templates/observe.html
@@ -375,7 +375,7 @@
           .then(r => r.json())
           .then(sats => {
               const sel = document.getElementById('satellite-select');
-              const prev = sel.value;
+              const prev = sel.value || document.querySelector("form input[name='x']").value;
               sel.innerHTML = '';
               const groups = {};
               sats.forEach(s => {


### PR DESCRIPTION
Fixes #269.

## Summary
- Pass the active satellite's NORAD ID as `commanded_x` when rendering the observe page, so the server communicates which satellite is currently tracked
- In `fetchSatellites()`, seed the previous-selection restore from the `x` input field as a fallback, so the correct satellite is re-selected in the dropdown after navigating away and back

## Test plan
- [ ] Select a non-first satellite in the GNSS dropdown, start tracking
- [ ] Navigate to Observations page, then back to Observe
- [ ] Verify the correct satellite is still selected in the dropdown
- [ ] Verify tracking continues on the same satellite without needing to re-select

🤖 Generated with [Claude Code](https://claude.com/claude-code)