### PR TITLE
Remove unused enabled field and fix test config coordinates

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -9,7 +9,6 @@ user_ids = [1]
 
 [[telescopes]]
 name = "fake1"
-enabled = true
 location = [ 11.9188, 57.3934 ]  # [longitude, latitude] in degrees
 min_elevation = 5.0  # in degrees
 stow_position = [ 90.0, 90.0 ]  # [azimuth, elevation] in degrees
@@ -17,7 +16,6 @@ telescope_type = "Fake"
 
 [[telescopes]]
 name = "fake2"
-enabled = true
 location = [ 11.9188, 57.3934 ]  # [longitude, latitude] in degrees
 min_elevation = 5.0  # in degrees
 stow_position = [ 90.0, 90.0 ]  # [azimuth, elevation] in degrees
@@ -27,7 +25,6 @@ telescope_type = "Fake"
 
 # [[telescopes]]
 # name = "vale"
-# enabled = true
 # location = [ 11.9188, 57.3934 ]  # [longitude, latitude] in degrees
 # min_elevation = 5.0  # in degrees
 # stow_position = [ 90.0, 90.0 ]  # [azimuth, elevation] in degrees

--- a/src/models/telescope_types.rs
+++ b/src/models/telescope_types.rs
@@ -64,7 +64,6 @@ pub enum TelescopeType {
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct TelescopeDefinition {
     pub name: String,
-    pub enabled: bool,
     pub location: [f64; 2],              // [longitude, latitude] in degrees
     pub min_elevation: f64,              // in degrees
     pub stow_position: Option<[f64; 2]>, // [azimuth, elevation] in degrees

--- a/tests/test_config/config.toml
+++ b/tests/test_config/config.toml
@@ -6,16 +6,14 @@ user_ids = []
 
 [[telescopes]]
 name = "fake1"
-enabled = true
-location = [ 0.20802143022, 1.00170457462 ]
-min_elevation = 0.087
+location = [ 11.9188, 57.3934 ]  # [longitude, latitude] in degrees
+min_elevation = 5.0  # in degrees
 stow_position = [ 90.0, 90.0 ]
 telescope_type = "Fake"
 
 [[telescopes]]
 name = "fake2"
-enabled = true
-location = [ 0.20802143022, 1.00170457462 ]
-min_elevation = 0.087
+location = [ 11.9188, 57.3934 ]  # [longitude, latitude] in degrees
+min_elevation = 5.0  # in degrees
 stow_position = [ 90.0, 90.0 ]
 telescope_type = "Fake"


### PR DESCRIPTION
## Summary
- Remove `enabled` from `TelescopeDefinition` — it was never acted on in code. Telescopes are included simply by being present in config, and maintenance mode already covers temporary unavailability.
- Fix `tests/test_config/config.toml` which had `location` and `min_elevation` in radians instead of degrees, causing incorrect telescope positions in tests.

## Test plan
- [ ] Verify existing tests still pass
- [ ] Verify fake telescopes still appear and work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)