### PR TITLE
Add receiver health check and show status in admin page

### DIFF
--- a/src/models/fake_telescope.rs
+++ b/src/models/fake_telescope.rs
@@ -220,6 +220,7 @@ impl Telescope for FakeTelescope {
             el_offset_rad: inner.el_offset_rad,
             location: inner.location,
             min_elevation_rad: inner.min_elevation_rad,
+            receiver_reachable: None,
         })
     }
     async fn shutdown(&self) {

--- a/src/models/salsa_telescope.rs
+++ b/src/models/salsa_telescope.rs
@@ -37,6 +37,7 @@ struct Inner {
     location: Location,
     min_elevation_rad: f64,
     t_rec_k: f64,
+    receiver_reachable: Arc<tokio::sync::Mutex<bool>>,
 }
 
 pub struct SalsaTelescope {
@@ -56,6 +57,10 @@ pub fn create(
     t_rec_k: f64,
     tle_cache: TleCacheHandle,
 ) -> SalsaTelescope {
+    let receiver_reachable = Arc::new(tokio::sync::Mutex::new(false));
+    let ping_reachable = receiver_reachable.clone();
+    let ping_address = receiver_address.clone();
+
     let inner = Arc::new(Mutex::new(Inner {
         name,
         receiver_address,
@@ -77,6 +82,7 @@ pub fn create(
         location,
         min_elevation_rad,
         t_rec_k,
+        receiver_reachable,
     }));
 
     let task_inner = inner.clone();
@@ -89,6 +95,23 @@ pub fn create(
                 }
             }
             tokio::time::sleep(TELESCOPE_UPDATE_INTERVAL).await;
+        }
+    });
+
+    tokio::spawn(async move {
+        loop {
+            let addr = ping_address.clone();
+            let reachable = tokio::task::spawn_blocking(move || {
+                std::process::Command::new("ping")
+                    .args(["-c", "1", "-W", "1", &addr])
+                    .output()
+                    .map(|o| o.status.success())
+                    .unwrap_or(false)
+            })
+            .await
+            .unwrap_or(false);
+            *ping_reachable.lock().await = reachable;
+            tokio::time::sleep(Duration::from_secs(5)).await;
         }
     });
 
@@ -160,6 +183,7 @@ impl Telescope for SalsaTelescope {
 
     async fn get_info(&self) -> Result<TelescopeInfo, TelescopeError> {
         let inner = self.inner.lock().await;
+        let receiver_reachable = *inner.receiver_reachable.lock().await;
         let controller_info = inner.controller.info()?;
 
         let latest_observation = {
@@ -192,6 +216,7 @@ impl Telescope for SalsaTelescope {
             el_offset_rad: controller_info.el_offset_rad,
             location: inner.location,
             min_elevation_rad: inner.min_elevation_rad,
+            receiver_reachable: Some(receiver_reachable),
         })
     }
     async fn shutdown(&self) {

--- a/src/models/telescope_types.rs
+++ b/src/models/telescope_types.rs
@@ -53,6 +53,7 @@ pub struct TelescopeInfo {
     pub el_offset_rad: f64,
     pub location: Location,
     pub min_elevation_rad: f64,
+    pub receiver_reachable: Option<bool>,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -35,7 +35,7 @@ fn require_admin(user: Option<User>) -> Result<User, StatusCode> {
 #[derive(Template)]
 #[template(path = "admin.html", escape = "none")]
 struct AdminTemplate {
-    telescopes: Vec<(String, bool, bool, bool)>, // (name, in_maintenance, is_booked_now, is_connected)
+    telescopes: Vec<(String, bool, bool, bool, Option<bool>)>, // (name, in_maintenance, is_booked_now, controller_connected, receiver_reachable)
     usage_from: NaiveDate,
     usage_to: NaiveDate,
     total_bookings: usize,
@@ -75,19 +75,25 @@ async fn get_admin(
     for name in telescope_names {
         let in_maintenance = maintenance.contains(&name);
         let is_booked_now = active_bookings.iter().any(|b| b.telescope_name == name);
-        let is_connected = if let Some(tel) = state.telescopes.get(&name).await {
-            tel.get_info().await.is_ok_and(|i| {
-                !matches!(
-                    i.most_recent_error,
-                    Some(
-                        TelescopeError::TelescopeIOError(_) | TelescopeError::TelescopeNotConnected
-                    )
-                )
-            })
+        let info = if let Some(tel) = state.telescopes.get(&name).await {
+            tel.get_info().await.ok()
         } else {
-            false
+            None
         };
-        telescopes.push((name, in_maintenance, is_booked_now, is_connected));
+        let is_connected = info.as_ref().is_some_and(|i| {
+            !matches!(
+                i.most_recent_error,
+                Some(TelescopeError::TelescopeIOError(_) | TelescopeError::TelescopeNotConnected)
+            )
+        });
+        let receiver_reachable = info.and_then(|i| i.receiver_reachable);
+        telescopes.push((
+            name,
+            in_maintenance,
+            is_booked_now,
+            is_connected,
+            receiver_reachable,
+        ));
     }
 
     let bookings = Booking::fetch_in_range(state.database_connection, from_dt, to_dt)

--- a/src/routes/observe.rs
+++ b/src/routes/observe.rs
@@ -599,6 +599,12 @@ async fn start_observe(
             "Telescope is not tracking. Please wait until it has reached the target.".to_string(),
         ));
     }
+    if info.receiver_reachable == Some(false) {
+        return Ok(error_response(
+            "Receiver is not reachable. Check the receiver address and network connection."
+                .to_string(),
+        ));
+    }
 
     let (freq_min, freq_max) = if user.is_admin {
         (FREQ_MIN_ADMIN_MHZ, FREQ_MAX_ADMIN_MHZ)

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -13,13 +13,14 @@
       <tr class="text-left text-gray-500 border-b">
         <th class="pb-2 pr-8">Telescope</th>
         <th class="pb-2 pr-8">Controller</th>
-        <th class="pb-2 pr-8">Status</th>
+        <th class="pb-2 pr-8">Receiver</th>
+        <th class="pb-2 pr-8">Maintenance</th>
         <th class="pb-2 pr-8">Current slot</th>
         <th class="pb-2"></th>
       </tr>
     </thead>
     <tbody>
-      {% for (name, in_maintenance, is_booked_now, is_connected) in telescopes %}
+      {% for (name, in_maintenance, is_booked_now, is_connected, receiver_reachable) in telescopes %}
       <tr class="border-b last:border-0">
         <td class="py-2 pr-8 font-medium">{{ name }}</td>
         <td class="py-2 pr-8">
@@ -27,6 +28,17 @@
           <span class="text-green-700">Online</span>
           {% else %}
           <span class="text-red-600 font-semibold">Offline</span>
+          {% endif %}
+        </td>
+        <td class="py-2 pr-8">
+          {% if let Some(reachable) = receiver_reachable %}
+            {% if reachable %}
+            <span class="text-green-700">Online</span>
+            {% else %}
+            <span class="text-red-600 font-semibold">Offline</span>
+            {% endif %}
+          {% else %}
+          <span class="text-gray-400">&mdash;</span>
           {% endif %}
         </td>
         <td class="py-2 pr-8">


### PR DESCRIPTION
## Summary
- Spawn a background task per Salsa telescope that pings the receiver address every 5s using `spawn_blocking` + `std::process::Command`
- Expose result as `receiver_reachable: Option<bool>` in `TelescopeInfo` (`None` for fake telescopes)
- Add a **Receiver** column to the admin status table (Online/Offline, or — for fake telescopes)
- Rename the **Status** column to **Maintenance** for clarity
- Gate observation start on receiver reachability: if the receiver ping has failed, `start_observe` returns a visible error rather than silently spawning a task that will fail asynchronously

## Test plan
- [ ] With correct receiver address, Receiver shows Online and observations start normally
- [ ] With wrong receiver address, Receiver shows Offline and clicking Start shows an error message
- [ ] Fake telescopes show — in the Receiver column
- [ ] Controller column behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)