### PR TITLE
Consolidate color palette

### DIFF
--- a/assets/colors.html
+++ b/assets/colors.html
@@ -9,217 +9,185 @@
 <body>
 <div class="section light">
   <h2 class="text-3xl font-semibold mb-2">Color palette</h2>
-  <p class="text-sm text-gray-500 mb-8">All colors defined in <code>@theme</code> in <code>style.src.css</code>. Edit values there and rebuild to see changes.</p>
+  <p class="text-sm text-neutral-500 mb-8">All colors defined in <code>@theme</code> in <code>style.src.css</code>. Edit values there and rebuild to see changes. 23 tokens, organised by semantic role.</p>
 
   <!-- Brand -->
-  <h3 class="text-lg font-semibold mb-3">Brand</h3>
+  <h3 class="text-lg font-semibold mb-1">Brand</h3>
+  <p class="text-sm text-neutral-500 mb-3">Structural surfaces: header, primary CTA, hero.</p>
   <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
       <div class="h-20 rounded-t bg-brand"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand<br><span class="text-gray-400">#02344a</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand<br><span class="text-neutral-500">#02344a</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-brand-light"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-light<br><span class="text-gray-400">#25617a</span></div>
+      <div class="h-20 rounded-t bg-brand-hover"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-hover<br><span class="text-neutral-500">#1d5170</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-brand-bg"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-bg<br><span class="text-gray-400">#f0f5f7</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-bg<br><span class="text-neutral-500">#eef4f7</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-brand-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-border<br><span class="text-gray-400">#d6e1e5</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-border<br><span class="text-neutral-500">#cfdde3</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-brand-dark"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-dark<br><span class="text-gray-400">#1a1d1f</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">brand-dark<br><span class="text-neutral-500">#0f1418</span></div>
     </div>
   </div>
 
-  <!-- Accent -->
-  <h3 class="text-lg font-semibold mb-3">Accent</h3>
+  <!-- Link & Focus -->
+  <h3 class="text-lg font-semibold mb-1">Link &amp; focus</h3>
+  <p class="text-sm text-neutral-500 mb-3">For in-content links and focus rings. Buttons use <code>brand</code>, not these.</p>
   <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
-      <div class="h-20 rounded-t bg-accent"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">accent<br><span class="text-gray-400">#4f46e5</span></div>
+      <div class="h-20 rounded-t bg-link"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">link<br><span class="text-neutral-500">#0e6b8c</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-accent-hover"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">accent-hover<br><span class="text-gray-400">#6366f1</span></div>
+      <div class="h-20 rounded-t bg-link-hover"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">link-hover<br><span class="text-neutral-500">#08506c</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-accent-dark"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">accent-dark<br><span class="text-gray-400">#3730a3</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-accent-light"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">accent-light<br><span class="text-gray-400">#e0e7ff</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-accent-focus"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">accent-focus<br><span class="text-gray-400">#818cf8</span></div>
+      <div class="h-20 rounded-t bg-focus"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">focus<br><span class="text-neutral-500">#3b9bbf</span></div>
     </div>
   </div>
 
-  <!-- Status -->
-  <h3 class="text-lg font-semibold mb-3">Status</h3>
+  <!-- Success -->
+  <h3 class="text-lg font-semibold mb-1">Success</h3>
+  <p class="text-sm text-neutral-500 mb-3">Online status, confirmations, success notifications.</p>
   <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
       <div class="h-20 rounded-t bg-success"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">success<br><span class="text-gray-400">#15803d</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">success<br><span class="text-neutral-500">#15803d</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-success-hover"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">success-hover<br><span class="text-gray-400">#16a34a</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">success-hover<br><span class="text-neutral-500">#16a34a</span></div>
     </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-success-bg"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">success-bg<br><span class="text-neutral-500">#e7f5ec</span></div>
+    </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-success-border"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">success-border<br><span class="text-neutral-500">#a7d8b6</span></div>
+    </div>
+  </div>
+
+  <!-- Warning -->
+  <h3 class="text-lg font-semibold mb-1">Warning</h3>
+  <p class="text-sm text-neutral-500 mb-3">Caution, maintenance, callouts. <code>warning-bg</code> replaces the old <code>callout</code>.</p>
+  <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
       <div class="h-20 rounded-t bg-warning"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning<br><span class="text-gray-400">#a16207</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-warning-light"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning-light<br><span class="text-gray-400">#fefce8</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning<br><span class="text-neutral-500">#9a6a07</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-warning-hover"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning-hover<br><span class="text-gray-400">#ca8a04</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning-hover<br><span class="text-neutral-500">#b07d09</span></div>
+    </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-warning-bg"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning-bg<br><span class="text-neutral-500">#fdf6e0</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-warning-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning-border<br><span class="text-gray-400">#fcd34d</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">warning-border<br><span class="text-neutral-500">#e8c97a</span></div>
     </div>
+  </div>
+
+  <!-- Danger -->
+  <h3 class="text-lg font-semibold mb-1">Danger</h3>
+  <p class="text-sm text-neutral-500 mb-3">Destructive actions, errors, offline status. Replaces old <code>delete</code> and <code>notify-error</code>.</p>
+  <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
       <div class="h-20 rounded-t bg-danger"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">danger<br><span class="text-gray-400">#dc2626</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">danger<br><span class="text-neutral-500">#c62828</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-danger-hover"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">danger-hover<br><span class="text-gray-400">#ef4444</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">danger-hover<br><span class="text-neutral-500">#dc2626</span></div>
     </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-danger-bg"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">danger-bg<br><span class="text-neutral-500">#fbe9e9</span></div>
+    </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-danger-border"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">danger-border<br><span class="text-neutral-500">#e8b3b3</span></div>
+    </div>
+  </div>
+
+  <!-- Info -->
+  <h3 class="text-lg font-semibold mb-1">Info</h3>
+  <p class="text-sm text-neutral-500 mb-3">Idle status, informational messages.</p>
+  <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
       <div class="h-20 rounded-t bg-info"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">info<br><span class="text-gray-400">#2563eb</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">info<br><span class="text-neutral-500">#1d4ed8</span></div>
+    </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-info-bg"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">info-bg<br><span class="text-neutral-500">#e6edfb</span></div>
     </div>
   </div>
 
-  <!-- Callout -->
-  <h3 class="text-lg font-semibold mb-3">Callout</h3>
+  <!-- Neutral ramp -->
+  <h3 class="text-lg font-semibold mb-1">Neutral ramp</h3>
+  <p class="text-sm text-neutral-500 mb-3">Text, muted text, borders, subtle surfaces. Slightly cool to harmonize with teal. Replaces all old <code>muted-*</code> and <code>subtle-border</code>.</p>
   <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
-      <div class="h-20 rounded-t bg-callout"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">callout<br><span class="text-gray-400">#fffbeb</span></div>
+      <div class="h-20 rounded-t bg-neutral-900"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">neutral-900<br><span class="text-neutral-500">#1a1d1f</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-callout-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">callout-border<br><span class="text-gray-400">#fcd34d</span></div>
-    </div>
-  </div>
-
-  <!-- Muted -->
-  <h3 class="text-lg font-semibold mb-3">Muted</h3>
-  <div class="flex flex-wrap gap-4 mb-8">
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-muted"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">muted<br><span class="text-gray-400">#555</span></div>
+      <div class="h-20 rounded-t bg-neutral-700"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">neutral-700<br><span class="text-neutral-500">#4b5258</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-muted-light"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">muted-light<br><span class="text-gray-400">#777</span></div>
+      <div class="h-20 rounded-t bg-neutral-500"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">neutral-500<br><span class="text-neutral-500">#7a8088</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-muted-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">muted-border<br><span class="text-gray-400">#ccc</span></div>
+      <div class="h-20 rounded-t bg-neutral-300"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">neutral-300<br><span class="text-neutral-500">#cfd4d8</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-subtle-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">subtle-border<br><span class="text-gray-400">#e0e0e0</span></div>
+      <div class="h-20 rounded-t bg-neutral-100"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">neutral-100<br><span class="text-neutral-500">#eef1f3</span></div>
     </div>
   </div>
 
   <!-- Calendar slots -->
-  <h3 class="text-lg font-semibold mb-3">Calendar slots</h3>
+  <h3 class="text-lg font-semibold mb-1">Calendar slots</h3>
+  <p class="text-sm text-neutral-500 mb-3">Aliased into semantic hues at calendar-friendly lightness. <code>slot-past</code> and <code>slot-disabled</code> now use <code>neutral-100</code>.</p>
   <div class="flex flex-wrap gap-4 mb-8">
     <div class="w-36">
       <div class="h-20 rounded-t bg-slot-free"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-free<br><span class="text-gray-400">#c8e6c9</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-free<br><span class="text-neutral-500">#bfe0c4</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-slot-free-hover"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-free-hover<br><span class="text-gray-400">#81c784</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-free-hover<br><span class="text-neutral-500">#8ec896</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-slot-mine"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-mine<br><span class="text-gray-400">#90caf9</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-mine<br><span class="text-neutral-500">#bcd2f0</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-slot-mine-hover"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-mine-hover<br><span class="text-gray-400">#64b5f6</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-mine-hover<br><span class="text-neutral-500">#8eb1e0</span></div>
     </div>
     <div class="w-36">
       <div class="h-20 rounded-t bg-slot-other"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-other<br><span class="text-gray-400">#ef9a9a</span></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-other<br><span class="text-neutral-500">#e8b3b3</span></div>
     </div>
     <div class="w-36">
-      <div class="h-20 rounded-t bg-slot-disabled"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-disabled<br><span class="text-gray-400">#e8e8e8</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-slot-past"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-past<br><span class="text-gray-400">#e0e0e0</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-slot-maintenance"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-maintenance<br><span class="text-gray-400">#fff3cd</span></div>
-    </div>
-  </div>
-
-  <!-- Notification -->
-  <h3 class="text-lg font-semibold mb-3">Notification</h3>
-  <div class="flex flex-wrap gap-4 mb-8">
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-notify-success"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">notify-success<br><span class="text-gray-400">#66BB6A</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-notify-success-bg"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">notify-success-bg<br><span class="text-gray-400">#E8F5E9</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-notify-error"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">notify-error<br><span class="text-gray-400">#E57373</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-notify-error-bg"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">notify-error-bg<br><span class="text-gray-400">#FFEBEE</span></div>
-    </div>
-  </div>
-
-  <!-- Booking actions -->
-  <h3 class="text-lg font-semibold mb-3">Booking actions</h3>
-  <div class="flex flex-wrap gap-4 mb-8">
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-observe"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">observe<br><span class="text-gray-400">#7b1fa2</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-observe-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">observe-border<br><span class="text-gray-400">#ce93d8</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-observe-bg"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">observe-bg<br><span class="text-gray-400">#f3e5f5</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-delete"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">delete<br><span class="text-gray-400">#c62828</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-delete-border"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">delete-border<br><span class="text-gray-400">#ef9a9a</span></div>
-    </div>
-    <div class="w-36">
-      <div class="h-20 rounded-t bg-delete-bg"></div>
-      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">delete-bg<br><span class="text-gray-400">#ffebee</span></div>
+      <div class="h-20 rounded-t bg-slot-maint"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">slot-maint<br><span class="text-neutral-500">#f3dca0</span></div>
     </div>
   </div>
 
@@ -230,19 +198,20 @@
       <button class="btn">Primary button</button>
       <button class="btn bg-danger hover:bg-danger-hover">Delete</button>
       <button class="btn bg-success hover:bg-success-hover">Success</button>
-      <button class="btn bg-warning-hover hover:bg-warning-hover">Warning</button>
+      <button class="btn bg-warning hover:bg-warning-hover">Warning</button>
     </div>
     <div class="flex flex-wrap gap-3 text-sm">
-      <span class="text-success font-semibold">Online</span>
-      <span class="text-danger font-semibold">Offline</span>
-      <span class="text-warning font-semibold">Maintenance</span>
-      <span class="text-info">Idle</span>
+      <span class="text-success font-semibold">● Online</span>
+      <span class="text-danger font-semibold">● Offline</span>
+      <span class="text-warning font-semibold">● Maintenance</span>
+      <span class="text-info">● Idle</span>
+      <a href="#" class="text-link hover:text-link-hover underline">In-content link</a>
     </div>
     <p class="callout">
-      This is a callout box using <code>bg-callout</code> and <code>border-callout-border</code>.
+      This is a callout box using <code>bg-warning-bg</code> and <code>border-warning-border</code>.
     </p>
-    <div class="callout bg-notify-success-bg border-notify-success">Success notification</div>
-    <div class="callout bg-notify-error-bg border-notify-error">Error notification</div>
+    <div class="callout bg-success-bg border-success-border">Success notification</div>
+    <div class="callout bg-danger-bg border-danger-border">Error notification</div>
   </div>
 </div>
 </body>

--- a/assets/colors.html
+++ b/assets/colors.html
@@ -133,6 +133,10 @@
       <div class="h-20 rounded-t bg-info-bg"></div>
       <div class="border border-t-0 rounded-b px-2 py-1 text-xs">info-bg<br><span class="text-neutral-500">#e6edfb</span></div>
     </div>
+    <div class="w-36">
+      <div class="h-20 rounded-t bg-info-border"></div>
+      <div class="border border-t-0 rounded-b px-2 py-1 text-xs">info-border<br><span class="text-neutral-500">#b6c5ed</span></div>
+    </div>
   </div>
 
   <!-- Neutral ramp -->
@@ -212,6 +216,7 @@
     </p>
     <div class="callout bg-success-bg border-success-border">Success notification</div>
     <div class="callout bg-danger-bg border-danger-border">Error notification</div>
+    <div class="callout bg-info-bg border-info-border">Info banner (e.g. guest-session notice)</div>
   </div>
 </div>
 </body>

--- a/assets/experiments-hi.html
+++ b/assets/experiments-hi.html
@@ -163,7 +163,7 @@
       atom: it has only one proton and one electron. Atomic hydrogen emits a radio
       line at a wavelength λ = 21 cm (or a frequency f = c/λ = 1420 MHz, where
       c ≅ 300 000 km/s is the speed of light). This is the signal we want to detect.</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         λ = 21 cm &nbsp;⟹&nbsp; f = c/λ = 1420 MHz &nbsp;&nbsp;&nbsp; (1.1)
       </div>
       <figure class="my-4" style="max-width: 480px;">
@@ -201,7 +201,7 @@
       velocity of the emitting hydrogen gas cloud, but to do so we need a formula.
       We chose to omit the rather long derivation and just state the important
       relation between the observed frequency shift and the velocity:</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         Δf / f₀ = −v / c &nbsp;&nbsp;&nbsp; (1.2)
       </div>
       <p>where:</p>
@@ -290,7 +290,7 @@
       directly. Instead, we measure the relative velocity, V<sub>r</sub>, between us
       and the cloud, projected on the line-of-sight. Using the angles in Fig. 2.1 we
       can write this down as</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         V<sub>r</sub> = V cos α − V₀ sin c &nbsp;&nbsp;&nbsp; (2.1)
       </div>
 
@@ -298,7 +298,7 @@
       coordinates we discussed in Sect. 1.2. We know that the sum of angles in the
       upper right triangle must be 180°, which means that we can relate the angle c to
       galactic longitude l as</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         (90 − l) + 90 + c = 180 &nbsp;⟹&nbsp; c = l &nbsp;&nbsp;&nbsp; (2.2)
       </div>
 
@@ -306,19 +306,19 @@
       angle between V and R is 90° and can be written as the sum of a and α, i.e.
       90° = b + α. From the triangle CMT we also note that b = 90° − a. Put together
       we get</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         90 = 90 − a + α &nbsp;⟹&nbsp; a = α &nbsp;&nbsp;&nbsp; (2.3)
       </div>
 
       <p>Looking at the triangles CST and CMT we find that the distance between the
       Galactic Center (C) and the tangential point (T) can be expressed in two
       different ways:</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         CT = R₀ sin l = R cos a &nbsp;⟹&nbsp; cos a = R₀ sin l / R &nbsp;&nbsp;&nbsp; (2.4)
       </div>
 
       <p>Using equations 2.2, 2.3, and 2.4 we can now re-write equation 2.1 as</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         V<sub>r</sub> = V (R₀/R) sin l − V₀ sin l &nbsp;&nbsp;&nbsp; (2.5)
       </div>
 
@@ -342,12 +342,12 @@
       since the maximum possible projected velocity happens when the projection angle is 0.
       For a cloud at the tangent point we see from Fig. 2.1 that the cloud location is
       given by</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         R = R₀ sin l &nbsp;&nbsp;&nbsp; (2.6)
       </div>
 
       <p>This simplifies equation 2.5 so that, at the tangential point, we have:</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         V = V<sub>r,max</sub> + V₀ sin l &nbsp;&nbsp;&nbsp; (2.7)
       </div>
 
@@ -394,16 +394,16 @@
       by the shape of our measured rotation curve we now assume that the gas in our
       Milky Way obeys <em>differential rotation</em>, i.e. the rotational speed is
       constant with radius and is the same as the rotational speed of the Sun, i.e.</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         V(R) = constant = V₀ &nbsp;&nbsp;&nbsp; (2.8)
       </div>
       <p>With this assumption, equation 2.5 simplifies to</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         V<sub>r</sub> = V₀ sin l (R₀/R − 1) &nbsp;&nbsp;&nbsp; (2.9)
       </div>
       <p>This equation can be re-written as an expression for the cloud distance R as
       a function of known (or observable, in the case of V<sub>r</sub>) quantities:</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         R = R₀ V₀ sin l / (V₀ sin l + V<sub>r</sub>) &nbsp;&nbsp;&nbsp; (2.10)
       </div>
 
@@ -425,13 +425,13 @@
       distance from the Sun to the cloud, i.e. the distance between the points S and M
       in Fig. 2.1. Using the law of cosines on the triangle CSM we obtain the following
       relation:</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         R² = R₀² + r² − 2 R₀ r cos l &nbsp;&nbsp;&nbsp; (2.11)
       </div>
       <p>This is a second-order equation in r, which has two possible solutions. If we
       denote these solutions r = r<sub>+</sub> and r = r<sub>−</sub>, we can write the
       solutions as</p>
-      <div class="callout bg-gray-50 border-accent-focus font-mono">
+      <div class="callout bg-gray-50 border-focus font-mono">
         r<sub>±</sub> = ±√(R² − R₀² sin²l) + R₀ cos l &nbsp;&nbsp;&nbsp; (2.12)
       </div>
 
@@ -457,7 +457,7 @@
         perpendicular coordinates x and y. To convert to x–y coordinates we need to
         relate them to r and l.</p>
         <p>You are probably familiar with <em>polar coordinates</em>, usually defined as</p>
-        <div class="callout bg-gray-50 border-accent-focus font-mono">
+        <div class="callout bg-gray-50 border-focus font-mono">
           x = r cos θ<br>
           y = r sin θ &nbsp;&nbsp;&nbsp; (2.13)
         </div>
@@ -470,7 +470,7 @@
         <p>It is clear that polar coordinates are very similar to our r, l-system. We
         find that θ = 270° + l, or θ = l − 90°. This means that we can convert our
         positions given as r, l to Cartesian x–y coordinates by:</p>
-        <div class="callout bg-gray-50 border-accent-focus font-mono">
+        <div class="callout bg-gray-50 border-focus font-mono">
           x = r cos(l − 90°)<br>
           y = r sin(l − 90°) &nbsp;&nbsp;&nbsp; (2.14)
         </div>
@@ -525,7 +525,7 @@
         <p>Think of a solid turntable, or a rotating DVD-disc. It rotates with a constant
         angular speed Ω = V/R = constant. The circular velocity is therefore proportional
         to the radius:</p>
-        <div class="callout bg-gray-50 border-accent-focus font-mono">
+        <div class="callout bg-gray-50 border-focus font-mono">
           V ∝ R &nbsp;&nbsp;&nbsp; (A.1)
         </div>
       </div>
@@ -550,13 +550,13 @@
         of the Sun. Therefore the center of mass of the Solar system is very close to
         the center of the Sun. The centrifugal acceleration from the planet's circular
         velocities counterbalances the gravitational acceleration:</p>
-        <div class="callout bg-gray-50 border-accent-focus font-mono">
+        <div class="callout bg-gray-50 border-focus font-mono">
           V²/R = GM/R² &nbsp;&nbsp;&nbsp; (A.2)
         </div>
         <p>where M is the mass and G the gravitational constant. The rotation curve is
         said to be <em>Keplerian</em>, and the velocities decrease with increasing
         radius:</p>
-        <div class="callout bg-gray-50 border-accent-focus font-mono">
+        <div class="callout bg-gray-50 border-focus font-mono">
           V<sub>Keplerian</sub>(R) = √(GM/R) &nbsp;&nbsp;&nbsp; (A.3)
         </div>
       </div>
@@ -567,7 +567,7 @@
         as a function of galacto-centric radius. In contrast to the rotation curve of
         systems like the Solar system with a large central mass, most galaxies exhibit
         flat rotation curves, that is, V(R) doesn't depend on R beyond a certain radius:</p>
-        <div class="callout bg-gray-50 border-accent-focus font-mono">
+        <div class="callout bg-gray-50 border-focus font-mono">
           V<sub>Galaxy</sub>(R) ~ constant &nbsp;&nbsp;&nbsp; (A.4)
         </div>
         <p>The angular velocity varies as Ω ∝ 1/R. Matter near the center rotates with

--- a/assets/style.src.css
+++ b/assets/style.src.css
@@ -33,6 +33,7 @@
 
   --color-info:           #1d4ed8;
   --color-info-bg:        #e6edfb;
+  --color-info-border:    #b6c5ed;
 
   /* ── Neutral ramp · 5 steps · cool to harmonise with teal ── */
   --color-neutral-900: #1a1d1f;  /* body text */
@@ -420,7 +421,7 @@ footer {
 .my-booking-description {
     flex-basis: 100%;
     font-size: 13px;
-    color: var(--color-muted);
+    color: var(--color-neutral-700);
     font-style: italic;
     margin-top: -4px;
 }
@@ -449,7 +450,7 @@ footer {
     background: var(--color-brand-bg);
 }
 .my-booking-observe-pending {
-    color: var(--color-muted);
+    color: var(--color-neutral-700);
     border-color: var(--color-brand-border);
     cursor: default;
     opacity: 0.7;

--- a/assets/style.src.css
+++ b/assets/style.src.css
@@ -3,67 +3,51 @@
 @source "../assets/";
 
 @theme {
-  /* Brand */
-  --color-brand: #02344a;
-  --color-brand-light: #25617a;
-  --color-brand-bg: #f0f5f7;
-  --color-brand-border: #d6e1e5;
-  --color-brand-dark: #1a1d1f;
+  /* ── Brand · structural surfaces ─────────────────────────── */
+  --color-brand:        #02344a;  /* header, primary CTA, calendar header */
+  --color-brand-hover:  #1d5170;  /* nav-link:hover, button:hover */
+  --color-brand-bg:     #eef4f7;  /* section.light bg */
+  --color-brand-border: #cfdde3;  /* card & row borders inside brand-bg */
+  --color-brand-dark:   #0f1418;  /* hero / starfield surface */
 
-  /* Interactive accent (buttons, links, focus rings) */
-  --color-accent: #4f46e5;
-  --color-accent-hover: #6366f1;
-  --color-accent-dark: #3730a3;
-  --color-accent-light: #e0e7ff;
-  --color-accent-focus: #818cf8;
+  /* ── Link & focus · derived from teal · replaces indigo accent ── */
+  --color-link:         #0e6b8c;
+  --color-link-hover:   #08506c;
+  --color-focus:        #3b9bbf;  /* focus ring · visible on light + dark */
 
-  /* Semantic status */
-  --color-success: #15803d;
-  --color-success-hover: #16a34a;
+  /* ── Semantic · 4-step scale per role ─────────────────────── */
+  --color-success:        #15803d;
+  --color-success-hover:  #16a34a;
+  --color-success-bg:     #e7f5ec;
+  --color-success-border: #a7d8b6;
 
-  --color-warning: #a16207;
-  --color-warning-light: #fefce8;
-  --color-warning-hover: #ca8a04;
-  --color-warning-border: #fcd34d;
+  --color-warning:        #9a6a07;
+  --color-warning-hover:  #b07d09;
+  --color-warning-bg:     #fdf6e0;  /* also: callout bg */
+  --color-warning-border: #e8c97a;
 
-  --color-danger: #dc2626;
-  --color-danger-hover: #ef4444;
+  --color-danger:         #c62828;
+  --color-danger-hover:   #dc2626;
+  --color-danger-bg:      #fbe9e9;
+  --color-danger-border:  #e8b3b3;
 
-  --color-info: #2563eb;
+  --color-info:           #1d4ed8;
+  --color-info-bg:        #e6edfb;
 
-  /* Callout boxes */
-  --color-callout: #fffbeb;
-  --color-callout-border: #fcd34d;
+  /* ── Neutral ramp · 5 steps · cool to harmonise with teal ── */
+  --color-neutral-900: #1a1d1f;  /* body text */
+  --color-neutral-700: #4b5258;  /* muted text */
+  --color-neutral-500: #7a8088;  /* tertiary text · ≥14px only (AA) */
+  --color-neutral-300: #cfd4d8;  /* borders */
+  --color-neutral-100: #eef1f3;  /* subtle borders, slot-past, slot-disabled */
 
-  /* Muted text and borders */
-  --color-muted: #555;
-  --color-muted-light: #777;
-  --color-muted-border: #ccc;
-  --color-subtle-border: #e0e0e0;
-
-  /* Calendar slots */
-  --color-slot-free: #c8e6c9;
-  --color-slot-free-hover: #81c784;
-  --color-slot-mine: #90caf9;
-  --color-slot-mine-hover: #64b5f6;
-  --color-slot-other: #ef9a9a;
-  --color-slot-disabled: #e8e8e8;
-  --color-slot-past: #e0e0e0;
-  --color-slot-maintenance: #fff3cd;
-
-  /* Notification */
-  --color-notify-success: #66BB6A;
-  --color-notify-success-bg: #E8F5E9;
-  --color-notify-error: #E57373;
-  --color-notify-error-bg: #FFEBEE;
-
-  /* Booking actions */
-  --color-observe: #7b1fa2;
-  --color-observe-border: #ce93d8;
-  --color-observe-bg: #f3e5f5;
-  --color-delete: #c62828;
-  --color-delete-border: #ef9a9a;
-  --color-delete-bg: #ffebee;
+  /* ── Calendar slots · aliased into semantic hue families ───── */
+  --color-slot-free:        #bfe0c4;  /* success hue, calendar lightness */
+  --color-slot-free-hover:  #8ec896;
+  --color-slot-mine:        #bcd2f0;  /* info hue */
+  --color-slot-mine-hover:  #8eb1e0;
+  --color-slot-other:       #e8b3b3;  /* = danger-border */
+  --color-slot-maint:       #f3dca0;  /* warning hue */
 }
 
 body {
@@ -104,7 +88,7 @@ body {
     background-color: var(--color-brand-dark);
 }
 .section a:not(.btn) {
-    color: var(--color-brand);
+    color: var(--color-link);
     text-decoration: none;
 }
 .section a:not(.btn):hover {
@@ -214,15 +198,15 @@ body {
 @layer components {
     .callout {
         @apply border-l-4 rounded px-4 py-2 text-sm my-2;
-        background-color: var(--color-callout);
-        border-color: var(--color-callout-border);
+        background-color: var(--color-warning-bg);
+        border-color: var(--color-warning-border);
     }
     .btn {
         @apply inline-block px-3 py-1 text-sm rounded-md text-white no-underline cursor-pointer;
-        background-color: var(--color-accent);
+        background-color: var(--color-brand);
     }
     .btn:hover {
-        background-color: var(--color-accent-hover);
+        background-color: var(--color-brand-hover);
     }
 }
 header {
@@ -281,7 +265,7 @@ header {
     align-items: center;
 }
 .nav-link:hover {
-    background-color: var(--color-brand-light);
+    background-color: var(--color-brand-hover);
 }
 
 .nav-spacer {
@@ -298,7 +282,7 @@ header {
     position: relative;
 }
 .nav-user-toggle:hover {
-    background-color: var(--color-brand-light);
+    background-color: var(--color-brand-hover);
 }
 .nav-user-dropdown {
     display: none;
@@ -382,7 +366,7 @@ body.user-open .nav-user-dropdown {
         min-width: 0;
         width: 100%;
         box-shadow: none;
-        border-top: 1px solid var(--color-brand-light);
+        border-top: 1px solid var(--color-brand-hover);
     }
 
     .nav-user-dropdown .nav-link {
@@ -396,8 +380,7 @@ body.user-open .nav-user-dropdown {
 }
 
 footer {
-    /* TODO: Need less contrast here */
-    color: var(--color-brand-border);
+    color: var(--color-neutral-500);
     padding: 20px;
     text-align: center;
     font-size: 90%;
@@ -432,7 +415,7 @@ footer {
 }
 .my-booking-time {
     font-size: 13px;
-    color: var(--color-muted);
+    color: var(--color-neutral-700);
 }
 .my-booking-description {
     flex-basis: 100%;
@@ -459,11 +442,11 @@ footer {
     background: var(--color-brand-border);
 }
 .my-booking-observe {
-    color: var(--color-observe);
-    border-color: var(--color-observe-border);
+    color: var(--color-brand);
+    border-color: var(--color-brand-border);
 }
 .my-booking-observe:hover {
-    background: var(--color-observe-bg);
+    background: var(--color-brand-bg);
 }
 .my-booking-observe-pending {
     color: var(--color-muted);
@@ -475,11 +458,11 @@ footer {
     background: white;
 }
 .my-booking-delete {
-    color: var(--color-delete);
-    border-color: var(--color-delete-border);
+    color: var(--color-danger);
+    border-color: var(--color-danger-border);
 }
 .my-booking-delete:hover {
-    background: var(--color-delete-bg);
+    background: var(--color-danger-bg);
 }
 
 /* Calendar navigation */
@@ -523,7 +506,7 @@ footer {
     background: white;
     cursor: pointer;
     font-size: 14px;
-    color: var(--color-muted);
+    color: var(--color-neutral-700);
 }
 .telescope-tab-btn:hover {
     background: var(--color-brand-bg);
@@ -546,7 +529,7 @@ footer {
     padding: 10px 14px;
     margin-bottom: 16px;
     font-size: 13px;
-    color: var(--color-muted);
+    color: var(--color-neutral-700);
 }
 .calendar-info-row {
     display: flex;
@@ -561,7 +544,7 @@ footer {
     font-family: 'Roboto Mono', monospace;
 }
 .calendar-help {
-    color: var(--color-muted-light);
+    color: var(--color-neutral-500);
     margin: 4px 0 0;
 }
 .calendar-legend {
@@ -581,7 +564,7 @@ footer {
     width: 16px;
     height: 16px;
     border-radius: 2px;
-    border: 1px solid var(--color-muted-border);
+    border: 1px solid var(--color-neutral-300);
 }
 
 /* Calendar grid */
@@ -613,7 +596,7 @@ footer {
     text-align: right;
     padding-right: 6px;
     font-size: 11px;
-    color: var(--color-muted);
+    color: var(--color-neutral-700);
     white-space: nowrap;
 }
 
@@ -621,7 +604,7 @@ footer {
 .calendar-slot {
     height: 22px;
     min-width: 80px;
-    border: 1px solid var(--color-subtle-border);
+    border: 1px solid var(--color-neutral-100);
     cursor: default;
 }
 
@@ -650,18 +633,18 @@ footer {
 
 /* Disabled — at booking limit */
 .calendar-slot-disabled {
-    background: var(--color-slot-disabled);
+    background: var(--color-neutral-100);
     cursor: not-allowed;
 }
 
 /* Past — gray */
 .calendar-slot-past {
-    background: var(--color-slot-past);
+    background: var(--color-neutral-100);
 }
 
 /* Maintenance — yellow */
 .calendar-slot-maintenance {
-    background: var(--color-slot-maintenance);
+    background: var(--color-slot-maint);
     cursor: not-allowed;
 }
 
@@ -680,12 +663,4 @@ footer {
 /* Lightbox */
 figure img {
     cursor: zoom-in;
-}
-
-/* Content links */
-.section a:not(.btn) {
-    color: var(--color-accent);
-}
-.section a:not(.btn):hover {
-    color: var(--color-accent-dark);
 }

--- a/assets/technical.html
+++ b/assets/technical.html
@@ -118,10 +118,10 @@ below.</p>
 
         <!-- Webserver: one box per column -->
         <div class="flex flex-col items-center">
-          <div class="border-2 border-accent rounded-lg px-12 py-2.5 bg-accent-light text-center font-semibold text-accent">SALSA webserver</div>
+          <div class="border-2 border-link rounded-lg px-12 py-2.5 bg-brand-bg text-center font-semibold text-link">SALSA webserver</div>
         </div>
         <div class="flex flex-col items-center">
-          <div class="border-2 border-accent rounded-lg px-12 py-2.5 bg-accent-light text-center font-semibold text-accent">SALSA webserver</div>
+          <div class="border-2 border-link rounded-lg px-12 py-2.5 bg-brand-bg text-center font-semibold text-link">SALSA webserver</div>
         </div>
 
         <!-- Bottom-left: FFT and Spectrum -->

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -131,7 +131,7 @@
         <td class="py-2 pr-8">
           <form method="post" action="/admin/local-users/{{ id }}/password" class="flex gap-2">
             <input type="password" name="password" placeholder="New password" required
-              class="border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-accent-focus w-36" />
+              class="border rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-focus w-36" />
             <button type="submit"
               class="btn">
               Set
@@ -157,11 +157,11 @@
   <form method="post" action="/admin/local-users" class="flex flex-col gap-2 max-w-xs">
     <h4 class="font-medium text-sm text-gray-700">Add local user</h4>
     <input type="text" name="username" placeholder="Username" required
-      class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-accent-focus" />
+      class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-focus" />
     <input type="password" name="password" placeholder="Password" required
-      class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-accent-focus" />
+      class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-focus" />
     <input type="text" name="comment" placeholder="Comment (optional)"
-      class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-accent-focus" />
+      class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-focus" />
     <button type="submit"
       class="btn self-start">
       Create

--- a/templates/bookings.html
+++ b/templates/bookings.html
@@ -1,6 +1,6 @@
 <div class="section light">
   {% for e in error %}
-  <div class="callout bg-notify-error-bg border-notify-error">{{ e }}</div>
+  <div class="callout bg-danger-bg border-danger-border">{{ e }}</div>
   {% endfor %}
 
   {% if is_admin %}
@@ -18,7 +18,7 @@
   {% if !my_bookings.is_empty() %}
   <div class="flex items-center gap-3 mb-3">
     <h2 class="text-xl font-semibold">Upcoming bookings</h2>
-    <a href="/bookings/export.ics" title="Export to calendar (.ics)" class="text-accent hover:text-accent-dark">
+    <a href="/bookings/export.ics" title="Export to calendar (.ics)" class="text-link hover:text-link-hover">
       <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-label="Export to calendar (.ics)">
         <path d="M19 3h-1V1h-2v2H8V1H6v2H5C3.9 3 3 3.9 3 5v16c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H5V8h14v13zM7 10h5v5H7z"/>
       </svg>
@@ -84,7 +84,7 @@
   <button class="telescope-tab-btn" onclick="selectTelescope({{ tel_idx }})">
     {{ telescope_names[tel_idx] }}
     {% if maintenance_telescopes[tel_idx] %}
-    <span class="text-xs font-semibold text-warning bg-warning-light px-2 py-0.5 rounded ml-2">Maintenance</span>
+    <span class="text-xs font-semibold text-warning bg-warning-bg px-2 py-0.5 rounded ml-2">Maintenance</span>
     {% endif %}
   </button>
   {% endfor %}

--- a/templates/interferometry_list.html
+++ b/templates/interferometry_list.html
@@ -149,8 +149,8 @@
   }
 
   function statusColor(s) {
-    if (s === 'Tracking') return 'bg-success-light text-success';
-    if (s === 'Slewing')  return 'bg-warning-light text-warning';
+    if (s === 'Tracking') return 'bg-success-bg text-success';
+    if (s === 'Slewing')  return 'bg-warning-bg text-warning';
     return 'bg-gray-100 text-gray-500';
   }
 

--- a/templates/interferometry_session.html
+++ b/templates/interferometry_session.html
@@ -86,7 +86,7 @@
       .attr('text-anchor', 'middle')
       .attr('transform', `translate(-42,${ih / 2}) rotate(-90)`)
       .attr('font-size', 11).attr('fill', '#555').text(yLabel);
-    return svg.append('path').attr('fill', 'none').attr('stroke', 'var(--color-accent)').attr('stroke-width', 1.5);
+    return svg.append('path').attr('fill', 'none').attr('stroke', 'var(--color-link)').attr('stroke-width', 1.5);
   }
 
   // ---- Amplitude vs frequency ----

--- a/templates/live_telescopes.html
+++ b/templates/live_telescopes.html
@@ -5,12 +5,12 @@
       <span class="font-semibold text-gray-700">{{ tel.name }}</span>
       <div class="flex gap-1">
         {% if tel.in_maintenance %}
-        <span class="text-xs font-semibold text-warning bg-warning-light px-2 py-0.5 rounded">Maintenance</span>
+        <span class="text-xs font-semibold text-warning bg-warning-bg px-2 py-0.5 rounded">Maintenance</span>
         {% endif %}
         {% if tel.status == "Tracking" %}
         <span class="text-xs font-semibold text-success bg-green-100 px-2 py-0.5 rounded">Tracking</span>
         {% else if tel.status == "Slewing" %}
-        <span class="text-xs font-semibold text-warning bg-warning-light px-2 py-0.5 rounded">Slewing</span>
+        <span class="text-xs font-semibold text-warning bg-warning-bg px-2 py-0.5 rounded">Slewing</span>
         {% else if tel.status == "Offline" %}
         <span class="text-xs font-semibold text-danger bg-red-100 px-2 py-0.5 rounded">Offline</span>
         {% else %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -28,9 +28,9 @@
           {% endif %}
           <form method="post" action="/auth/local" class="flex flex-col gap-2">
             <input type="text" name="username" placeholder="Username" required
-              class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-accent-focus" />
+              class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-focus" />
             <input type="password" name="password" placeholder="Password" required
-              class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-accent-focus" />
+              class="border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-focus" />
             <button type="submit"
               class="bg-gray-700 hover:bg-gray-600 text-white font-medium py-2 px-4 rounded text-sm">
               Log in

--- a/templates/observations.html
+++ b/templates/observations.html
@@ -168,9 +168,9 @@
             </div>
             <div class="flex gap-2 flex-wrap">
               <button id="btn-fit-baseline" onclick="fitBaseline()" disabled
-                class="text-xs px-2 py-1 bg-accent-light text-accent rounded hover:bg-accent-light disabled:opacity-40 disabled:cursor-not-allowed">Fit</button>
+                class="text-xs px-2 py-1 bg-brand-bg text-link rounded hover:bg-brand-bg disabled:opacity-40 disabled:cursor-not-allowed">Fit</button>
               <button id="btn-subtract-baseline" onclick="subtractBaseline()" disabled
-                class="text-xs px-2 py-1 bg-accent-light text-accent rounded hover:bg-accent-light disabled:opacity-40 disabled:cursor-not-allowed">Subtract</button>
+                class="text-xs px-2 py-1 bg-brand-bg text-link rounded hover:bg-brand-bg disabled:opacity-40 disabled:cursor-not-allowed">Subtract</button>
               <button onclick="clearBaseline()" class="text-xs px-2 py-1 bg-gray-100 rounded hover:bg-gray-200">Clear</button>
             </div>
           </div>
@@ -184,7 +184,7 @@
             </div>
             <div class="flex gap-2">
               <button id="btn-fit-gaussian" onclick="fitGaussians()" disabled
-                class="text-xs px-2 py-1 bg-accent-light text-accent rounded hover:bg-accent-light disabled:opacity-40 disabled:cursor-not-allowed">Fit</button>
+                class="text-xs px-2 py-1 bg-brand-bg text-link rounded hover:bg-brand-bg disabled:opacity-40 disabled:cursor-not-allowed">Fit</button>
               <button onclick="clearGaussians()" class="text-xs px-2 py-1 bg-gray-100 rounded hover:bg-gray-200">Clear</button>
             </div>
             <div id="gaussian-results" class="text-xs text-gray-600 space-y-1 font-mono"></div>

--- a/templates/observe.html
+++ b/templates/observe.html
@@ -2,7 +2,7 @@
 <div id="observe-section" class="section light">
   <div id="errors" class="mb-1"></div>
   {% if in_maintenance %}
-  <div class="text-sm font-semibold text-warning bg-warning-light border border-warning-border rounded px-3 py-2 mb-2">
+  <div class="text-sm font-semibold text-warning bg-warning-bg border border-warning-border rounded px-3 py-2 mb-2">
     This telescope is currently in maintenance mode.
   </div>
   {% endif %}
@@ -41,7 +41,7 @@
       <div id="telescope-status" hx-get="/telescope/{{ info.id }}/state" hx-trigger="every 1s">{{ state_html }}</div>
 
       <!-- Booking warning (shown at T-5min) -->
-      <div id="booking-warning" class="hidden text-sm font-semibold text-warning bg-warning-light border border-warning-border rounded px-3 py-2"></div>
+      <div id="booking-warning" class="hidden text-sm font-semibold text-warning bg-warning-bg border border-warning-border rounded px-3 py-2"></div>
 
       <!-- Target input -->
       <div>

--- a/templates/observe.html
+++ b/templates/observe.html
@@ -14,14 +14,14 @@
   {% if let Some(started_at) = guest_started_at %}
     {% if let Some(last_activity_at) = guest_last_activity_at %}
   <div id="guest-banner"
-       class="text-sm bg-info-light border border-info-border rounded px-3 py-2 mb-2 flex items-start gap-3 flex-wrap"
+       class="text-sm bg-info-bg border border-info-border rounded px-3 py-2 mb-2 flex items-start gap-3 flex-wrap"
        data-started-at="{{ started_at }}"
        data-last-activity-at="{{ last_activity_at }}"
        data-idle-secs="{{ guest_idle_secs }}"
        data-ceiling-secs="{{ guest_ceiling_secs }}">
     <div class="flex-1 min-w-0 leading-snug">
       <span class="font-semibold">Guest session</span> —
-      ends in <span id="guest-countdown-time" class="font-semibold text-accent">…</span>
+      ends in <span id="guest-countdown-time" class="font-semibold text-link">…</span>
       <span id="guest-countdown-note" class="text-gray-600"></span>,
       or sooner if a registered user books this telescope. Data is not saved.
     </div>


### PR DESCRIPTION
## Summary
- Collapse 45 ad-hoc color tokens to 23 organised by role.
- Replace the indigo `accent` with a teal-derived `link`/`focus` pair, retire the purple "observe" colour, and fold notify-/callout-/delete- duplicates into the status scales.
- Add `--color-info-border` to round out the 4-step scale used by success/warning/danger.
- Buttons are now brand-teal; in-content links use `--color-link`; the footer drops to `--color-neutral-500`.

## Notes
- Fix `.btn` links inside `.section`. They are now exempt from the `.section a` colour rule, so `text-brand` etc. actually apply (was silently overridden before).
- Calendar slot CSS class names stay structural (`.calendar-slot-past`, `-disabled`, `-maintenance`); only the underlying `--color-*` tokens moved.
- `assets/colors.html` shows the full palette and usage examples.
                                                                                                                                        