### PR TITLE
Add per-user timezone support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1702,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,6 +2208,7 @@ dependencies = [
  "axum-server",
  "base64",
  "chrono",
+ "chrono-tz",
  "clap 4.6.0",
  "db_ip",
  "deadpool-sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ axum = { version = "0.8.*", features = ["json", "ws"] }
 axum-server = { version = "0.7.*", features = ["tls-rustls"] }
 base64 = { version = "0.22.*" }
 chrono = { version = "0.4.*", features = ["serde"] }
+chrono-tz = "0.10"
 clap = { version = "4.*", features = ["derive", "env"] }
 deadpool-sqlite = { version = "0.10", features = ["rt_tokio_1"] }
 oauth2 = "5.*"

--- a/assets/user-manual.html
+++ b/assets/user-manual.html
@@ -41,6 +41,12 @@
     already have an account with. Once logged in your name will appear in the top
     navigation bar. Clicking it reveals account settings and a log out link.</p>
 
+    <p><strong>Timezone.</strong> Dates and times across the site are shown in your
+    local timezone. On your first login the browser's timezone is detected and saved
+    automatically — a small banner confirms which zone was picked. You can change it
+    at any time from the account settings page by choosing a different timezone. If no
+    zone is set, times are shown in UTC.</p>
+
     <p><strong>Just want to try?</strong> The <strong>Observe now</strong> button on
     the welcome page starts a guest session on the first available telescope without
     asking for a login. Guest sessions are short (up to 30 minutes, and they release
@@ -72,8 +78,11 @@
     limited number of upcoming bookings at a time. To cancel a booking, click your blue slot
     and confirm the cancellation.</p>
 
-    <p>The page shows the current UTC time so you can plan accordingly. All times in the
-    calendar are in UTC.</p>
+    <p>The calendar and the current-time clock are shown in your local timezone (see
+    <a href="#account">Creating an account</a> for how this is set). Note that each
+    bookable slot is always a whole UTC hour regardless of your timezone, so if your
+    zone is offset by a half or quarter hour the slot labels will show times like
+    :30 or :45.</p>
 
     <p>Not every target is observable at every time of day — the SALSA telescopes
     can only point above the horizon at Onsala, Sweden. To check when a target

--- a/sql_migrations/V16__add_user_timezone.sql
+++ b/sql_migrations/V16__add_user_timezone.sql
@@ -1,0 +1,4 @@
+-- Per-user preferred IANA timezone (e.g. 'Europe/Stockholm') for displaying
+-- dates and times. NULL means "not chosen yet" — the UI auto-detects the
+-- browser timezone on first login and treats NULL as UTC until then.
+ALTER TABLE user ADD COLUMN timezone TEXT;

--- a/src/booking_monitor.rs
+++ b/src/booking_monitor.rs
@@ -40,6 +40,7 @@ pub fn start(state: AppState) {
                         name: b.user_name.clone(),
                         provider: b.user_provider.clone(),
                         is_admin: false,
+                        timezone: None,
                     });
                     let previous_user = active_users.get(telescope_name).cloned();
 

--- a/src/guest_monitor.rs
+++ b/src/guest_monitor.rs
@@ -102,6 +102,7 @@ pub async fn end_session(state: &AppState, guest: &GuestSession, reason: EndReas
         name: format!("guest-{}", guest.user_id),
         provider: "guest".to_string(),
         is_admin: false,
+        timezone: None,
     };
     if let Some(telescope) = state.telescopes.get(&guest.telescope_id).await {
         stop_and_save_observation(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,6 @@ pub mod secrets;
 pub mod supervised_task;
 pub mod telescope_controller;
 pub mod telescope_tracker;
+pub mod timefmt;
 pub mod tle_cache;
 pub mod weather_cache;

--- a/src/models/guest.rs
+++ b/src/models/guest.rs
@@ -172,6 +172,7 @@ impl GuestSession {
             name: username,
             provider: "guest".to_string(),
             is_admin: false,
+            timezone: None,
         };
         let started_at = DateTime::<Utc>::from_timestamp(now_ts, 0).unwrap_or_default();
         let session = Session {

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -120,7 +120,7 @@ impl Session {
         let conn = connection.lock().await;
         let oldest_allowed = Utc::now().timestamp() - SESSION_LIFETIME_SECS;
         match conn.query_row(
-            "SELECT token, user.id, username, provider FROM session \
+            "SELECT token, user.id, username, provider, timezone FROM session \
              INNER JOIN user ON session.user_id = user.id \
              WHERE session.token = (?1) AND session.created_at > (?2)",
             (token, oldest_allowed),
@@ -134,16 +134,21 @@ impl Session {
                         .expect("Table 'user' has known layout"),
                     row.get::<usize, String>(3)
                         .expect("Table 'user' has known layout"),
+                    row.get::<usize, Option<String>>(4)
+                        .expect("Table 'user' has known layout"),
                 ))
             },
         ) {
-            Ok((token, user_id, username, provider)) => Ok(Some(Session {
+            Ok((token, user_id, username, provider, timezone)) => Ok(Some(Session {
                 token: token.to_string(),
                 user: User {
                     id: user_id,
                     name: username,
                     provider,
                     is_admin: false,
+                    // Stored names are validated on write; ignore anything
+                    // unparseable (treated as UTC) rather than failing login.
+                    timezone: timezone.and_then(|name| name.parse().ok()),
                 },
             })),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -15,6 +15,10 @@ pub struct User {
     pub name: String,
     pub provider: String,
     pub is_admin: bool,
+    /// Preferred IANA timezone for displaying dates and times. `None` until
+    /// the user picks one (or it's auto-detected from the browser on first
+    /// login); treated as UTC for display via [`User::tz`].
+    pub timezone: Option<chrono_tz::Tz>,
 }
 
 async fn hash_password(password: String) -> Result<String, InternalError> {
@@ -30,6 +34,32 @@ async fn hash_password(password: String) -> Result<String, InternalError> {
 }
 
 impl User {
+    /// Effective display timezone, defaulting to UTC when the user hasn't
+    /// chosen one yet.
+    pub fn tz(&self) -> chrono_tz::Tz {
+        self.timezone.unwrap_or(chrono_tz::UTC)
+    }
+
+    /// Persist the user's preferred timezone. The value is validated
+    /// against the IANA database before storing so we never keep junk, and
+    /// the canonical name is written back.
+    pub async fn set_timezone(
+        connection: Arc<Mutex<Connection>>,
+        user_id: i64,
+        timezone: &str,
+    ) -> Result<(), InternalError> {
+        let tz: chrono_tz::Tz = timezone
+            .parse()
+            .map_err(|_| InternalError::new(format!("Invalid timezone: {timezone}")))?;
+        let conn = connection.lock().await;
+        conn.execute(
+            "UPDATE user SET timezone = ?1 WHERE id = ?2",
+            (tz.name(), user_id),
+        )
+        .map_err(|e| InternalError::new(format!("Failed to update timezone: {e}")))?;
+        Ok(())
+    }
+
     pub async fn create_from_external(
         connection: Arc<Mutex<Connection>>,
         name: String,
@@ -47,6 +77,7 @@ impl User {
             name,
             provider,
             is_admin: false,
+            timezone: None,
         })
     }
 
@@ -94,6 +125,7 @@ impl User {
             name: username,
             provider: "local".to_string(),
             is_admin: false,
+            timezone: None,
         })
     }
 
@@ -144,6 +176,7 @@ impl User {
                 name,
                 provider: "local".to_string(),
                 is_admin: false,
+                timezone: None,
             }))
         } else {
             Ok(None)
@@ -321,6 +354,7 @@ impl User {
                     name: row.get(1)?,
                     provider: row.get(2).unwrap_or_default(),
                     is_admin: false,
+                    timezone: None,
                 })
             })
             .map_err(|err| InternalError::new(format!("Failed to query users: {err}")))?;
@@ -354,6 +388,7 @@ impl User {
                 name,
                 provider,
                 is_admin: false,
+                timezone: None,
             })),
             Err(Error::QueryReturnedNoRows) => Ok(None),
             Err(err) => Err(InternalError::new(format!(

--- a/src/routes/account.rs
+++ b/src/routes/account.rs
@@ -1,11 +1,12 @@
 use askama::Template;
 use axum::{
-    Extension, Router,
+    Extension, Form, Router,
     extract::State,
     http::{HeaderMap, HeaderValue, StatusCode, header::SET_COOKIE},
     response::{Html, IntoResponse, Response},
     routing::{get, post},
 };
+use serde::Deserialize;
 use tracing::{error, info};
 
 use crate::app::AppState;
@@ -16,14 +17,44 @@ use crate::routes::index::render_main;
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/", get(get_account))
+        .route("/timezone", post(set_timezone))
         .route("/delete", post(delete_account))
         .with_state(state)
+}
+
+/// One option in the timezone picker.
+struct TzOption {
+    name: &'static str,
+    selected: bool,
 }
 
 #[derive(Template)]
 #[template(path = "account.html", escape = "none")]
 struct AccountTemplate {
     user: User,
+    /// All IANA timezones for the picker (alphabetical), with the user's
+    /// current one marked selected.
+    timezones: Vec<TzOption>,
+    /// Set after a successful save so the page can confirm it.
+    saved: bool,
+}
+
+impl AccountTemplate {
+    fn new(user: User, saved: bool) -> Self {
+        let current = user.tz();
+        let timezones = chrono_tz::TZ_VARIANTS
+            .iter()
+            .map(|tz| TzOption {
+                name: tz.name(),
+                selected: *tz == current,
+            })
+            .collect();
+        AccountTemplate {
+            user,
+            timezones,
+            saved,
+        }
+    }
 }
 
 async fn get_account(
@@ -31,7 +62,7 @@ async fn get_account(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, StatusCode> {
     let user = user.ok_or(StatusCode::UNAUTHORIZED)?;
-    let content = AccountTemplate { user: user.clone() }
+    let content = AccountTemplate::new(user.clone(), false)
         .render()
         .expect("Template rendering should always succeed");
     let content = if headers.get("hx-request").is_some() {
@@ -39,6 +70,35 @@ async fn get_account(
     } else {
         render_main(Some(user), content)
     };
+    Ok(Html(content))
+}
+
+#[derive(Deserialize)]
+struct TimezoneForm {
+    timezone: String,
+}
+
+/// Persist the user's preferred timezone. Used both by the profile-page
+/// picker (htmx) and by the one-shot browser-timezone auto-detect on first
+/// login (plain `fetch`). Returns the refreshed Account card so htmx can
+/// swap it in; the auto-detect caller ignores the body.
+async fn set_timezone(
+    Extension(user): Extension<Option<User>>,
+    State(state): State<AppState>,
+    Form(form): Form<TimezoneForm>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let mut user = user.ok_or(StatusCode::UNAUTHORIZED)?;
+    User::set_timezone(state.database_connection.clone(), user.id, &form.timezone)
+        .await
+        .map_err(|err| {
+            error!("Failed to set timezone: {err:?}");
+            StatusCode::BAD_REQUEST
+        })?;
+    // Reflect the new value in the re-rendered card.
+    user.timezone = form.timezone.parse().ok();
+    let content = AccountTemplate::new(user, true)
+        .render()
+        .expect("Template rendering should always succeed");
     Ok(Html(content))
 }
 

--- a/src/routes/booking.rs
+++ b/src/routes/booking.rs
@@ -5,6 +5,7 @@ use crate::models::maintenance::fetch_maintenance_set;
 use crate::models::support_announcement::fetch_support_announcement;
 use crate::models::user::User;
 use crate::routes::index::render_main;
+use crate::timefmt::InTz;
 use askama::Template;
 use axum::extract::{ConnectInfo, Path, Query};
 use axum::http::{HeaderMap, HeaderValue, header};
@@ -16,7 +17,8 @@ use axum::{
     http::StatusCode,
     routing::{delete, get},
 };
-use chrono::{DateTime, Datelike, Duration, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, Offset, TimeZone, Utc};
+use chrono_tz::Tz;
 use serde::Deserialize;
 use std::net::SocketAddr;
 
@@ -35,6 +37,9 @@ pub enum SlotStatus {
     MineActive,
     OtherUser,
     Past,
+    /// A local-time grid cell that maps to no bookable hour because the
+    /// user's clocks skipped it on a DST spring-forward day.
+    Unavailable,
 }
 
 #[derive(Debug, Clone)]
@@ -47,12 +52,21 @@ pub struct CalendarSlot {
     pub booked_by: Option<String>,
 }
 
+/// Lay out the calendar grid in the user's local timezone. The bookable
+/// unit stays a whole UTC hour (identical for every user, regardless of
+/// their zone); this only chooses which (local day, local hour) cell each
+/// canonical slot is shown in, and labels rows with local time. `off_min`
+/// is the minute component of the zone's UTC offset (0 for whole-hour
+/// zones, 30/45 for the half/quarter-hour ones) so the local wall-clock
+/// time of every cell lands exactly on a whole UTC hour.
 fn build_calendar_slots(
     week_start: NaiveDate,
     telescope_names: &[String],
     bookings: &[Booking],
     user: &User,
     now: DateTime<Utc>,
+    tz: Tz,
+    off_min: u32,
 ) -> Vec<Vec<Vec<CalendarSlot>>> {
     let mut result = Vec::new();
 
@@ -62,7 +76,27 @@ fn build_calendar_slots(
             let day = week_start + Duration::days(day_offset);
             let mut day_slots = Vec::new();
             for hour in 0..24 {
-                let start_time = day.and_hms_opt(hour, 0, 0).unwrap().and_utc();
+                // Map this local wall-clock cell back to its UTC instant.
+                let naive = day.and_hms_opt(hour, off_min, 0).unwrap();
+                let start_time = match tz.from_local_datetime(&naive) {
+                    LocalResult::Single(dt) => dt.with_timezone(&Utc),
+                    // DST fall-back: two instants share this local time;
+                    // show the earliest, the later one is just unreachable
+                    // from the grid that day.
+                    LocalResult::Ambiguous(dt, _) => dt.with_timezone(&Utc),
+                    // DST spring-forward: this local hour doesn't exist.
+                    LocalResult::None => {
+                        day_slots.push(CalendarSlot {
+                            start_time: now,
+                            telescope_name: telescope.clone(),
+                            status: SlotStatus::Unavailable,
+                            booking_id: None,
+                            is_current_hour: false,
+                            booked_by: None,
+                        });
+                        continue;
+                    }
+                };
                 let end_time = start_time + Duration::hours(1);
 
                 let is_current_hour = now >= start_time && now < end_time;
@@ -131,6 +165,9 @@ struct BookingsTemplate {
     next_week: String,
     days: Vec<NaiveDate>,
     hours: Vec<u32>,
+    /// Local wall-clock label for each grid row (e.g. "16:00", or "16:30"
+    /// in half-hour zones), indexed by hour 0..24.
+    hour_labels: Vec<String>,
     slots: Vec<Vec<Vec<CalendarSlot>>>,
     upcoming_count: usize,
     max_upcoming_bookings: u32,
@@ -139,6 +176,12 @@ struct BookingsTemplate {
     viewed_user_id: i64,
     all_users: Vec<User>,
     announcement: Option<String>,
+    /// Display timezone, used by `.in_tz(tz)` calls in the template.
+    tz: Tz,
+    /// IANA name (e.g. "Europe/Stockholm") for the help text and JS.
+    tz_name: String,
+    /// Current zone abbreviation (e.g. "CEST") for column/label headers.
+    tz_abbr: String,
 }
 
 async fn get_bookings(
@@ -161,7 +204,11 @@ async fn get_bookings(
         user.id
     };
     let now = Utc::now();
-    let week_start = week_monday(query.week.unwrap_or(now.date_naive()));
+    let week_start = week_monday(
+        query
+            .week
+            .unwrap_or(now.with_timezone(&user.tz()).date_naive()),
+    );
     let content = build_bookings_page(&state, &user, viewed_user_id, now, week_start, None).await?;
 
     let content = if headers.get("hx-request").is_some() {
@@ -245,15 +292,19 @@ async fn create_booking(
         if inserted {
             None
         } else {
+            let local = start_time.with_timezone(&user.tz());
             Some(format!(
                 "Slot at {} on {} is already booked.",
-                start_time.format("%H:%M"),
-                start_time.format("%Y-%m-%d"),
+                local.format("%H:%M %Z"),
+                local.format("%Y-%m-%d"),
             ))
         }
     };
 
-    let week_start = week_monday(form.week.unwrap_or(now.date_naive()));
+    let week_start = week_monday(
+        form.week
+            .unwrap_or(now.with_timezone(&user.tz()).date_naive()),
+    );
     let content = build_bookings_page(&state, &user, user.id, now, week_start, error).await?;
 
     let content = if headers.get("hx-request").is_some() {
@@ -291,7 +342,11 @@ async fn delete_booking(
     }
 
     let now = Utc::now();
-    let week_start = week_monday(query.week.unwrap_or(now.date_naive()));
+    let week_start = week_monday(
+        query
+            .week
+            .unwrap_or(now.with_timezone(&user.tz()).date_naive()),
+    );
     let viewed_user_id = if user.is_admin {
         query.user_id.unwrap_or(user.id)
     } else {
@@ -365,6 +420,20 @@ async fn build_bookings_page(
     week_start: NaiveDate,
     error: Option<String>,
 ) -> Result<String, StatusCode> {
+    let tz = user.tz();
+    // Minute component of the current UTC offset (0, 30 or 45). The whole
+    // grid is laid out at this minute past the local hour so every cell
+    // maps to a whole UTC hour.
+    let off_min = (now
+        .with_timezone(&tz)
+        .offset()
+        .fix()
+        .local_minus_utc()
+        .rem_euclid(3600)
+        / 60) as u32;
+    let tz_name = tz.name().to_string();
+    let tz_abbr = now.with_timezone(&tz).format("%Z").to_string();
+
     let week_end = week_start + Duration::days(6);
     let prev_week = (week_start - Duration::weeks(1))
         .format("%Y-%m-%d")
@@ -374,6 +443,7 @@ async fn build_bookings_page(
         .to_string();
     let days: Vec<NaiveDate> = (0..7).map(|d| week_start + Duration::days(d)).collect();
     let hours: Vec<u32> = (0..24).collect();
+    let hour_labels: Vec<String> = (0..24).map(|h| format!("{h:02}:{off_min:02}")).collect();
 
     let mut telescope_names = state.telescopes.get_names().await;
     let preferred_order = ["torre", "vale", "brage"];
@@ -408,7 +478,15 @@ async fn build_bookings_page(
         .ok()
         .flatten();
 
-    let slots = build_calendar_slots(week_start, &telescope_names, &all_bookings, user, now);
+    let slots = build_calendar_slots(
+        week_start,
+        &telescope_names,
+        &all_bookings,
+        user,
+        now,
+        tz,
+        off_min,
+    );
 
     let upcoming_count = my_bookings.len();
     let max_upcoming_bookings = state.booking_config.max_upcoming_bookings;
@@ -428,6 +506,7 @@ async fn build_bookings_page(
         next_week,
         days,
         hours,
+        hour_labels,
         slots,
         upcoming_count,
         max_upcoming_bookings,
@@ -436,6 +515,9 @@ async fn build_bookings_page(
         viewed_user_id,
         all_users,
         announcement,
+        tz,
+        tz_name,
+        tz_abbr,
     }
     .render()
     .expect("Template rendering should always succeed");

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -17,6 +17,9 @@ struct IndexTemplate {
     content: String,
     build_url: String,
     version_description: String,
+    /// True for a logged-in, non-guest user who hasn't set a timezone yet,
+    /// triggering a one-shot browser-timezone auto-detect in the layout.
+    detect_timezone: bool,
 }
 
 #[derive(Deserialize)]
@@ -193,6 +196,9 @@ pub fn render_main(user: Option<User>, content: String) -> String {
     };
     let is_admin = user.as_ref().is_some_and(|u| u.is_admin);
     let is_guest = user.as_ref().is_some_and(|u| u.provider == "guest");
+    let detect_timezone = user
+        .as_ref()
+        .is_some_and(|u| u.provider != "guest" && u.timezone.is_none());
     let name = match &user {
         Some(u) => u.name.clone(),
         None => String::new(),
@@ -204,6 +210,7 @@ pub fn render_main(user: Option<User>, content: String) -> String {
         content,
         build_url,
         version_description,
+        detect_timezone,
     }
     .render()
     .expect("Template should always succeed")

--- a/src/routes/interferometry.rs
+++ b/src/routes/interferometry.rs
@@ -9,6 +9,7 @@ use crate::routes::index::render_main;
 use crate::routes::observe::{
     FREQ_MAX_ADMIN_MHZ, FREQ_MAX_USER_MHZ, FREQ_MIN_ADMIN_MHZ, FREQ_MIN_USER_MHZ,
 };
+use crate::timefmt::InTz;
 
 use askama::Template;
 use axum::extract::{Path, Query, State};
@@ -727,6 +728,8 @@ struct SessionTemplate {
     back_url: String,
     back_label: String,
     max_rows_per_response: i64,
+    /// Display timezone, used by `.in_tz(tz)` calls in the template.
+    tz: chrono_tz::Tz,
 }
 
 #[derive(Deserialize)]
@@ -801,6 +804,7 @@ async fn get_session(
         back_url,
         back_label,
         max_rows_per_response: MAX_VISIBILITY_ROWS_PER_REQUEST,
+        tz: user.tz(),
     }
     .render()
     .expect("template ok");

--- a/src/routes/observations.rs
+++ b/src/routes/observations.rs
@@ -4,6 +4,7 @@ use crate::models::interferometry::InterferometrySession;
 use crate::models::observation::Observation;
 use crate::models::user::User;
 use crate::routes::index::render_main;
+use crate::timefmt::InTz;
 use askama::Template;
 use axum::extract::{Path, Query, State};
 use axum::http::header;
@@ -11,6 +12,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{Html, IntoResponse, Json, Redirect, Response};
 use axum::{Extension, Router, routing::get};
 use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
 
 const PAGE_SIZE: i64 = 10;
@@ -65,6 +67,8 @@ struct ObservationsTemplate {
     total_count: i64,
     // interferometry fields
     interferometry_sessions: Vec<InterfSessionRow>,
+    /// Display timezone, used by `.in_tz(tz)` calls in the template.
+    tz: Tz,
 }
 
 fn make_interf_rows(
@@ -100,6 +104,7 @@ fn build_observations_template(
     all_users: Vec<User>,
     show_interferometry_tab: bool,
     interferometry_sessions: Vec<InterfSessionRow>,
+    tz: Tz,
 ) -> ObservationsTemplate {
     let total_pages = ((total_count as usize).saturating_sub(1) / PAGE_SIZE as usize) + 1;
     let current_page = current_page.min(total_pages.max(1));
@@ -126,6 +131,7 @@ fn build_observations_template(
         all_users,
         show_interferometry_tab,
         interferometry_sessions,
+        tz,
     }
 }
 
@@ -201,6 +207,7 @@ async fn get_observations(
         all_users,
         show_interferometry_tab,
         interferometry_sessions,
+        user.tz(),
     )
     .render()
     .expect("Template rendering should always succeed");
@@ -252,6 +259,7 @@ async fn delete_observation(
         vec![],
         interf_count > 0,
         vec![],
+        user.tz(),
     )
     .render()
     .expect("Template rendering should always succeed");
@@ -320,6 +328,7 @@ async fn delete_interferometry_session(
         vec![],
         show_interferometry_tab,
         interferometry_sessions,
+        user.tz(),
     )
     .render()
     .expect("Template rendering should always succeed");

--- a/src/timefmt.rs
+++ b/src/timefmt.rs
@@ -1,0 +1,17 @@
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+
+/// Extension trait for rendering a UTC timestamp in a user's chosen
+/// timezone. Used from Askama templates as `dt.in_tz(tz)` so every
+/// date/time rendering path shares one conversion. `Tz` is `Copy`, so it
+/// passes cleanly as a by-value template argument, and the resulting
+/// `DateTime<Tz>` formats with `%Z` to show the local zone abbreviation.
+pub trait InTz {
+    fn in_tz(&self, tz: &Tz) -> DateTime<Tz>;
+}
+
+impl InTz for DateTime<Utc> {
+    fn in_tz(&self, tz: &Tz) -> DateTime<Tz> {
+        self.with_timezone(tz)
+    }
+}

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,4 +1,4 @@
-<div class="section light">
+<div class="section light" id="account-card">
   <h2 class="text-xl font-semibold mb-4">Account</h2>
   <dl class="text-sm space-y-2 grid grid-cols-[max-content_auto] gap-x-4 gap-y-1">
     <dt class="text-gray-500">Username</dt>
@@ -10,6 +10,29 @@
     <dt class="text-gray-500">Account type</dt>
     <dd>{% if user.is_admin %}Admin{% else %}User{% endif %}</dd>
   </dl>
+
+  <div class="mt-6 pt-4 border-t border-gray-200">
+    <label for="timezone-select" class="block text-sm font-medium text-gray-700 mb-1">Timezone</label>
+    <p class="text-sm text-gray-500 mb-2">
+      Dates and times across SALSA — including the bookings calendar — are shown in this timezone.
+    </p>
+    <div class="flex items-center gap-3 flex-wrap">
+      <select id="timezone-select" name="timezone"
+        hx-post="/account/timezone"
+        hx-trigger="change"
+        hx-target="#account-card"
+        hx-swap="outerHTML"
+        class="border rounded px-2 py-1 text-sm bg-white">
+        {% for tz in timezones %}
+        <option value="{{ tz.name }}"{% if tz.selected %} selected{% endif %}>{{ tz.name }}</option>
+        {% endfor %}
+      </select>
+      {% if saved %}
+      <span class="text-sm text-success">Saved ✓ — applies as you navigate.</span>
+      {% endif %}
+    </div>
+  </div>
+
   <p class="text-sm text-gray-600 mt-6 pt-4 border-t border-gray-200">
     Enjoying SALSA? We'd love to hear about it — what you observed,
     what surprised you, what you used the data for. Drop us a line at

--- a/templates/bookings.html
+++ b/templates/bookings.html
@@ -38,7 +38,7 @@
     <div class="my-booking-row">
       <div class="my-booking-info">
         <span class="my-booking-telescope">{{ booking.telescope_name }}</span>
-        <span class="my-booking-time">{{ booking.start_time.format("%Y-%m-%d %H:%M") }}&ndash;{{ booking.end_time.format("%H:%M") }} UTC</span>
+        <span class="my-booking-time">{{ booking.start_time.in_tz(tz).format("%Y-%m-%d %H:%M") }}&ndash;{{ booking.end_time.in_tz(tz).format("%H:%M %Z") }}</span>
         {% if let Some(desc) = booking.description %}
         <span class="my-booking-description">{{ desc }}</span>
         {% endif %}
@@ -47,7 +47,7 @@
         {% if booking.active_at(now) %}
         <a href="observe/{{ booking.telescope_name }}" class="my-booking-btn my-booking-observe">Observe</a>
         {% else %}
-        <span class="my-booking-btn my-booking-observe my-booking-observe-pending" title="Observe opens at {{ booking.start_time.format("%Y-%m-%d %H:%M") }} UTC">Observe</span>
+        <span class="my-booking-btn my-booking-observe my-booking-observe-pending" title="Observe opens at {{ booking.start_time.in_tz(tz).format("%Y-%m-%d %H:%M %Z") }}">Observe</span>
         {% endif %}
         <button
           hx-delete="bookings/{{ booking.id }}?week={{ week_start }}{% if is_admin %}&user_id={{ viewed_user_id }}{% endif %}"
@@ -84,7 +84,7 @@
       <span class="legend-item"><span class="legend-swatch calendar-slot-past"></span> Past</span>
       <span class="legend-item"><span class="legend-swatch calendar-slot-maintenance"></span> Maintenance</span>
     </div>
-    <p class="calendar-help">All times are in UTC. Click a green slot to book it. Click a blue slot to cancel.</p>
+    <p class="calendar-help">All times are shown in your timezone ({{ tz_name }}, {{ tz_abbr }}) &mdash; change it on your <a href="/account">profile</a>. Click a green slot to book it. Click a blue slot to cancel.</p>
   </div>
 
   <div class="telescope-tabs">
@@ -100,14 +100,14 @@
   </div>
 
   <script>
+  var SALSA_TZ = "{{ tz_name }}";
   (function() {
     function updateClock() {
-      var now = new Date();
-      var h = String(now.getUTCHours()).padStart(2, '0');
-      var m = String(now.getUTCMinutes()).padStart(2, '0');
-      var s = String(now.getUTCSeconds()).padStart(2, '0');
       var el = document.getElementById('utc-clock');
-      if (el) el.textContent = h + ':' + m + ':' + s + ' UTC';
+      if (el) el.textContent = new Intl.DateTimeFormat('sv-SE', {
+        timeZone: SALSA_TZ, hour: '2-digit', minute: '2-digit',
+        second: '2-digit', hour12: false, timeZoneName: 'short'
+      }).format(new Date());
     }
     updateClock();
     setInterval(updateClock, 1000);
@@ -131,7 +131,7 @@
     <table class="calendar-grid">
       <thead>
         <tr>
-          <th class="calendar-hour-label">UTC</th>
+          <th class="calendar-hour-label">{{ tz_abbr }}</th>
           {% for day in days %}
           <th class="calendar-header-cell">{{ day.format("%a %d") }}</th>
           {% endfor %}
@@ -140,7 +140,7 @@
       <tbody>
         {% for hour in hours %}
         <tr>
-          <td class="calendar-hour-label">{{ hour }}:00</td>
+          <td class="calendar-hour-label">{{ hour_labels[hour as usize] }}</td>
           {% for day_idx in 0..7 %}
           {% let slot = slots[tel_idx][day_idx][hour as usize] %}
           {% match slot.status %}
@@ -151,7 +151,7 @@
               hx-target="#page"
               hx-confirm="book"
               hx-vals='{"start_timestamp": {{ slot.start_time.timestamp() }}, "telescope": "{{ slot.telescope_name }}", "week": "{{ week_start }}"}'
-              title="Book {{ slot.telescope_name }} at {{ slot.start_time.format("%Y-%m-%d %H:%M") }} UTC (maintenance mode)"
+              title="Book {{ slot.telescope_name }} at {{ slot.start_time.in_tz(tz).format("%Y-%m-%d %H:%M %Z") }} (maintenance mode)"
               style="cursor: pointer;">
           </td>
           {% else if maintenance_telescopes[tel_idx] %}
@@ -168,7 +168,7 @@
               hx-target="#page"
               hx-confirm="book"
               hx-vals='{"start_timestamp": {{ slot.start_time.timestamp() }}, "telescope": "{{ slot.telescope_name }}", "week": "{{ week_start }}"}'
-              title="Book {{ slot.telescope_name }} at {{ slot.start_time.format("%Y-%m-%d %H:%M") }} UTC">
+              title="Book {{ slot.telescope_name }} at {{ slot.start_time.in_tz(tz).format("%Y-%m-%d %H:%M %Z") }}">
           </td>
           {% endif %}
           {% when SlotStatus::Mine %}
@@ -209,6 +209,9 @@
           {% when SlotStatus::Past %}
           <td class="calendar-slot calendar-slot-past">
           </td>
+          {% when SlotStatus::Unavailable %}
+          <td class="calendar-slot calendar-slot-past" title="This hour does not exist in your timezone (daylight-saving change)">
+          </td>
           {% endmatch %}
           {% endfor %}
         </tr>
@@ -234,7 +237,7 @@
       <div id="confirm-dialog-range" class="hidden mb-4">
         <label class="text-sm text-gray-600">Until:
           <select id="confirm-dialog-until" class="ml-1 border rounded px-2 py-1 bg-white text-sm"></select>
-          <span class="text-gray-500 text-xs ml-1">UTC</span>
+          <span class="text-gray-500 text-xs ml-1">{{ tz_abbr }}</span>
         </label>
       </div>
       <div id="confirm-dialog-description-wrap" class="hidden mb-4">
@@ -265,19 +268,20 @@
     var slotData = [];
     var remaining = {% if is_admin %}9999{% else %}{{ max_upcoming_bookings }} - {{ upcoming_count }}{% endif %};
 
-    function pad(n) { return String(n).padStart(2, '0'); }
-    function tsToUTC(ts) {
-      var d = new Date(parseInt(ts, 10) * 1000);
-      return d.getUTCFullYear() + '-' + pad(d.getUTCMonth()+1) + '-' + pad(d.getUTCDate()) +
-        ' ' + pad(d.getUTCHours()) + ':' + pad(d.getUTCMinutes());
+    function tsToLocalDateTime(ts) {
+      return new Intl.DateTimeFormat('sv-SE', { timeZone: SALSA_TZ,
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', hour12: false })
+        .format(new Date(parseInt(ts, 10) * 1000));
     }
-    function tsToTime(ts) {
-      var d = new Date(parseInt(ts, 10) * 1000);
-      return pad(d.getUTCHours()) + ':' + pad(d.getUTCMinutes());
+    function tsToLocalTime(ts) {
+      return new Intl.DateTimeFormat('sv-SE', { timeZone: SALSA_TZ,
+        hour: '2-digit', minute: '2-digit', hour12: false })
+        .format(new Date(parseInt(ts, 10) * 1000));
     }
-    function tsEndTime(ts) {
-      return tsToTime(parseInt(ts, 10) + 3600);
-    }
+    function tsEndTime(ts) { return tsToLocalTime(parseInt(ts, 10) + 3600); }
+    var SALSA_TZ_ABBR = ((new Intl.DateTimeFormat('en', { timeZone: SALSA_TZ, timeZoneName: 'short' })
+      .formatToParts(new Date()).find(function(p) { return p.type === 'timeZoneName'; })) || {}).value || '';
 
     function getConsecutiveAfter(td, cls) {
       var row = td.parentElement;
@@ -329,7 +333,7 @@
           document.getElementById('confirm-dialog-title').textContent = 'Confirm booking';
           document.getElementById('confirm-dialog-msg').innerHTML =
             'Book <strong class="text-gray-900">' + (vals.telescope||'') + '</strong>' +
-            ' from <strong class="text-gray-900">' + tsToTime(vals.start_timestamp) + '</strong> UTC';
+            ' from <strong class="text-gray-900">' + tsToLocalTime(vals.start_timestamp) + '</strong> ' + SALSA_TZ_ABBR;
           slotData.forEach(function(s) {
             var o = document.createElement('option');
             o.textContent = tsEndTime(s.vals.start_timestamp);
@@ -341,7 +345,7 @@
           document.getElementById('confirm-dialog-title').textContent = 'Confirm booking';
           document.getElementById('confirm-dialog-msg').innerHTML =
             'Book <strong class="text-gray-900">' + (vals.telescope||'') + '</strong>' +
-            ' at <strong class="text-gray-900">' + tsToUTC(vals.start_timestamp) + '</strong> UTC?';
+            ' at <strong class="text-gray-900">' + tsToLocalDateTime(vals.start_timestamp) + '</strong> ' + SALSA_TZ_ABBR + '?';
           ok.textContent = 'Book 1 slot';
         }
 
@@ -362,7 +366,7 @@
           document.getElementById('confirm-dialog-title').textContent = 'Cancel booking';
           document.getElementById('confirm-dialog-msg').innerHTML =
             'Cancel <strong class="text-gray-900">' + tel + '</strong>' +
-            ' from <strong class="text-gray-900">' + tsToTime(ts) + '</strong> UTC' + bookedBySuffix;
+            ' from <strong class="text-gray-900">' + tsToLocalTime(ts) + '</strong> ' + SALSA_TZ_ABBR + bookedBySuffix;
           slotData.forEach(function(s) {
             var o = document.createElement('option');
             o.textContent = tsEndTime(s.ts);
@@ -375,7 +379,7 @@
           document.getElementById('confirm-dialog-title').textContent = 'Cancel booking';
           document.getElementById('confirm-dialog-msg').innerHTML =
             'Cancel <strong class="text-gray-900">' + tel + '</strong>' +
-            ' at <strong class="text-gray-900">' + tsToUTC(ts) + '</strong> UTC?' + bookedBySuffix;
+            ' at <strong class="text-gray-900">' + tsToLocalDateTime(ts) + '</strong> ' + SALSA_TZ_ABBR + '?' + bookedBySuffix;
           ok.textContent = 'Cancel booking';
         }
       }

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,6 +90,59 @@
         <footer>
             Made by weirdos 🦆 ({% if build_url == "" %} {{version_description}} {% else %} <a href={{build_url}}>{{version_description}}</a> {% endif %})
         </footer>
+        {% if detect_timezone %}
+        <script>
+            // First login without a saved timezone: detect the browser's
+            // IANA zone once, store it, and reload so times render locally.
+            // The flag is read back after the reload to confirm it to the user.
+            (function() {
+                try {
+                    var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                    if (!tz) return;
+                    fetch('/account/timezone', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: 'timezone=' + encodeURIComponent(tz)
+                    }).then(function(r) {
+                        if (r.ok) {
+                            try { sessionStorage.setItem('salsa-tz-autoset', tz); } catch (e) {}
+                            location.reload();
+                        }
+                    });
+                } catch (e) { /* leave timezone unset; stays UTC */ }
+            })();
+        </script>
+        {% endif %}
+        <script>
+            // One-shot confirmation toast after a timezone was auto-detected.
+            (function() {
+                var tz;
+                try { tz = sessionStorage.getItem('salsa-tz-autoset'); } catch (e) { return; }
+                if (!tz) return;
+                try { sessionStorage.removeItem('salsa-tz-autoset'); } catch (e) {}
+                var toast = document.createElement('div');
+                toast.className = 'callout bg-info-bg border-info-border text-info';
+                toast.style.cssText = 'position:fixed;bottom:1rem;right:1rem;max-width:24rem;z-index:1100;box-shadow:0 4px 12px rgba(0,0,0,0.15);display:flex;gap:0.75rem;align-items:flex-start';
+                var msg = document.createElement('div');
+                msg.style.flex = '1';
+                msg.append('Timezone set to ');
+                var strong = document.createElement('strong');
+                strong.textContent = tz;
+                msg.append(strong, ' from your browser. Change it on your ');
+                var link = document.createElement('a');
+                link.href = '/account';
+                link.textContent = 'profile';
+                msg.append(link, '.');
+                var close = document.createElement('button');
+                close.setAttribute('aria-label', 'Dismiss');
+                close.textContent = '✕';
+                close.style.cssText = 'flex-shrink:0;cursor:pointer;line-height:1';
+                close.onclick = function() { toast.remove(); };
+                toast.append(msg, close);
+                document.body.appendChild(toast);
+                setTimeout(function() { toast.remove(); }, 10000);
+            })();
+        </script>
         <div id="lightbox" onclick="this.classList.add('hidden');this.classList.remove('flex')" class="hidden fixed inset-0 bg-black/85 z-[1000] cursor-zoom-out items-center justify-center p-8">
             <img id="lightbox-img" class="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-[0_0_60px_rgba(0,0,0,0.5)]">
         </div>

--- a/templates/interferometry_session.html
+++ b/templates/interferometry_session.html
@@ -16,9 +16,9 @@
   </div>
 
   <div class="text-sm text-gray-500 mb-6 flex flex-wrap gap-x-6 gap-y-1">
-    <span>Start: {{ session.start_time.format("%Y-%m-%d %H:%M:%S UTC") }}</span>
+    <span>Start: {{ session.start_time.in_tz(tz).format("%Y-%m-%d %H:%M:%S %Z") }}</span>
     {% if let Some(et) = session.end_time %}
-    <span>End: {{ et.format("%Y-%m-%d %H:%M:%S UTC") }}</span>
+    <span>End: {{ et.in_tz(tz).format("%Y-%m-%d %H:%M:%S %Z") }}</span>
     {% endif %}
     <span>Target: {{ target_label }}</span>
     <span>{{ center_freq_mhz|fmt("{:.3}") }} MHz &plusmn; {{ half_bw_mhz|fmt("{:.2}") }} MHz</span>

--- a/templates/observations.html
+++ b/templates/observations.html
@@ -40,12 +40,12 @@
     {% for s in interferometry_sessions %}
     <div class="hover:bg-gray-100 p-2 rounded border border-transparent text-sm flex justify-between items-center">
       <a href="/interferometry/{{ s.id }}" class="flex-1 min-w-0">
-        {{ s.start_time.format("%Y-%m-%d %H:%M") }}
+        {{ s.start_time.in_tz(tz).format("%Y-%m-%d %H:%M") }}
         &mdash; {{ s.telescope_a }} &times; {{ s.telescope_b }}
         &mdash; {{ s.target_label }}
         &mdash; {{ s.center_freq_mhz|fmt("{:.1}") }} MHz
         {% if let Some(et) = s.end_time %}
-        &mdash; ended {{ et.format("%H:%M") }}
+        &mdash; ended {{ et.in_tz(tz).format("%H:%M %Z") }}
         {% else %}
         &mdash; <span class="text-warning">no end time</span>
         {% endif %}
@@ -75,7 +75,7 @@
             class="hover:bg-gray-100 p-2 rounded border border-transparent text-sm flex flex-col sm:flex-row justify-between items-start sm:items-center"
           >
             <span class="cursor-pointer" onclick="loadObservation({{ obs.id }})">
-              {{ obs.start_time.naive_local() }} &mdash;
+              {{ obs.start_time.in_tz(tz).format("%Y-%m-%d %H:%M %Z") }} &mdash;
               {{ obs.telescope_id }},
               {{ obs.coordinate_system }} ({{ obs.target_x|fmt("{:.1}") }}, {{ obs.target_y|fmt("{:.1}") }}),
               {{ obs.integration_time_secs|fmt("{:.0}") }}s


### PR DESCRIPTION
Closes #308.

Bookings, observations and interferometry pages previously rendered all times in UTC. Users can now choose an IANA timezone, and every date/time across the app is displayed in it.

## Behaviour
- **Existing users:** default to UTC. A timezone picker (all ~600 IANA zones) is on the profile page (`/account`).
- **New users:** on first login the browser timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) is auto-detected and saved once, then editable on the profile — no blocking prompt. A one-shot dismissible banner confirms the detected zone. Guests are excluded so their observing sessions aren't disturbed.

## Booking calendar design
The bookable unit stays a **whole UTC hour for every user**, regardless of their zone — only the layout and labels change. The grid is laid out in local time (local day columns, local hour rows). For whole-hour offsets the row labels are clean (`16:00`); for half/quarter-hour zones they read `16:30` / `16:45`, but the underlying slot is still the same whole UTC hour everyone else books. This keeps bookings fully consistent across timezones (verified: slot timestamps remain divisible by 3600 even in Asia/Kolkata +5:30). DST spring-forward gaps render as unavailable cells; fall-back ambiguity shows the earliest instant.

## Implementation
- New nullable `user.timezone` column (migration `V16`); `NULL` = not chosen yet, treated as UTC via `User::tz()`. Loaded in the session fetch.
- Shared `InTz` template helper (`src/timefmt.rs`) converts UTC instants for server-side rendering as `dt.in_tz(tz).format("…%Z")`.
- The bookings live clock and confirmation dialogs convert client-side using the user's zone (`Intl.DateTimeFormat` with `timeZone`).
- `POST /account/timezone` validates against the IANA database before storing (invalid → 400); used by both the picker and the auto-detect.

## Testing
- `cargo fmt` / `clippy` clean; all tests pass.
- Smoke-tested against a populated DB: V16 migrates cleanly; verified Kolkata (`:30` labels, IST, whole-hour timestamps), Stockholm (`:00`, CEST, local day headers), profile save/persist, invalid → 400, and the first-login auto-detect + confirmation banner toggling on the `timezone` column.

## Known limitation
The interferometry D3 plot axes still read "UTC time" — d3 time scales are local-or-UTC only, so arbitrary-IANA tick formatting is a larger separate change, left out of scope.