### PR TITLE
Apply the LO offset only up to 5 MHz bandwidth, on the DDC null

### DIFF
--- a/src/models/salsa_telescope.rs
+++ b/src/models/salsa_telescope.rs
@@ -496,14 +496,30 @@ fn measure_switched(
     Ok(())
 }
 
-/// LO offset for direct-conversion tuning (see measure_single): half the
-/// bandwidth to clear the kept passband, plus a guard of 10% of the
-/// bandwidth (at least 0.5 MHz) so the band's inner edge also clears the
-/// LO phase-noise skirt and the near-DC 1/f noise region. Kept as small
-/// as that allows: v1.2.0 used a full bandwidth, which pushed the outer
-/// band edge onto the analog filter slope and tilted the passband.
+/// Widest bandwidth that still gets LO-offset tuning. Sun spectra
+/// (2026-07-18) showed the MAX2112's intrinsic baseband response is flat
+/// to ~7 MHz from centre but droops ~1.4 dB by 15 MHz and ~4 dB by
+/// 23 MHz, so at 10 and 25 MHz no offset keeps the band flat — those
+/// revert to plain centre tuning, whose narrow DC dip is far less
+/// harmful there than a multi-dB tilt. (The 10 MHz dome seen in the
+/// same tests is unrelated CIC droop: decimation 10 engages only one
+/// compensating halfband. Present with or without the offset.)
+const LO_OFFSET_MAX_BW_HZ: f64 = 5e6;
+
+/// LO offset for direct-conversion tuning (see measure_single): exactly
+/// one bandwidth, i.e. one output sample rate. The DDC's decimation
+/// chain has a deep null there, so the LO leakage/DC artifact is
+/// annihilated rather than merely attenuated — a fractional offset
+/// (tried in v1.2.1) parks the artifact in the decimation filters'
+/// transition band, and its alias folds back into the passband as a
+/// narrow spike at (bandwidth − offset) from centre. Zero — plain
+/// centre tuning — above [`LO_OFFSET_MAX_BW_HZ`].
 fn lo_offset_hz(bandwidth_hz: f64) -> f64 {
-    0.5 * bandwidth_hz + (0.1 * bandwidth_hz).max(0.5e6)
+    if bandwidth_hz <= LO_OFFSET_MAX_BW_HZ {
+        bandwidth_hz
+    } else {
+        0.0
+    }
 }
 
 /// DBSRX2 analog filter setting: wide open at its 80 MHz maximum. The


### PR DESCRIPTION
Third iteration of #311, informed by Sun spectra at all four bandwidths on v1.2.1:

- **2.5 and 5 MHz were flat** — the wide-open analog filter works there.
- **The 5 MHz spectrum showed a narrow spike at exactly 2 MHz from centre**: the fractional offset (bw/2 + guard) parked the DC artifact in the decimation filters' transition band, and its alias folded back in-band at (bandwidth − offset). The offset is now **exactly one bandwidth**, which lands on the DDC chain's deep null — the classic UHD convention, and now we know why.
- **10 and 25 MHz revert to plain centre tuning.** The MAX2112's intrinsic baseband droop (~1.4 dB at 15 MHz out, ~4 dB at 23 MHz, read off the 25 MHz test spectrum) makes any offset produce a worse artifact (multi-dB tilt) than the narrow dip it removes.
- The symmetric **dome at 10 MHz is pre-existing CIC droop** (decimation 10 engages only one compensating halfband), present with or without the offset — noted in the code, could be compensated digitally as a separate improvement.

Verification: 2.5 and 5 MHz should be flat with no dip and no spike; 10 and 25 MHz should look exactly as they did before v1.2.0 (dip back, no tilt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121WWae5AjEW8jxz349F93r