### PR TITLE
Record the receiver settings an observation was taken with

### DIFF
--- a/sql_migrations/V18__add_observation_receiver_settings.sql
+++ b/sql_migrations/V18__add_observation_receiver_settings.sql
@@ -1,0 +1,17 @@
+-- Receiver settings the observation was taken with. Until now only the target
+-- and integration time were kept, so an archived spectrum could not be told
+-- apart from one taken at a different gain or in a different observation mode.
+-- Diagnosing receiver compression on Vale (issue #317) depended entirely on
+-- knowing the gain, which was recorded nowhere.
+--
+-- Nullable throughout: rows written before this migration have no settings to
+-- recover. Centre frequency and bandwidth are derivable from frequencies_json
+-- for old rows, but are stored explicitly from now on so a reader does not
+-- have to reconstruct them.
+ALTER TABLE observation ADD COLUMN gain_db REAL;
+ALTER TABLE observation ADD COLUMN center_freq_hz REAL;
+ALTER TABLE observation ADD COLUMN ref_freq_hz REAL;
+ALTER TABLE observation ADD COLUMN bandwidth_hz REAL;
+ALTER TABLE observation ADD COLUMN spectral_channels INTEGER;
+ALTER TABLE observation ADD COLUMN observation_mode TEXT;
+ALTER TABLE observation ADD COLUMN rfi_filter INTEGER;

--- a/src/models/fake_telescope.rs
+++ b/src/models/fake_telescope.rs
@@ -206,12 +206,11 @@ impl Telescope for FakeTelescope {
             }
             info!("Starting integration on {}", &inner.name);
             inner.current_spectra.clear();
-            inner.receiver_configuration.integrate = true;
-            // The fake receiver simulates neither frequency nor gain, so the
-            // rest of the configuration is ignored — but the requested
-            // duration governs when the integration ends, which it does have
-            // to honour.
-            inner.receiver_configuration.max_duration = receiver_configuration.max_duration;
+            // The fake receiver simulates neither frequency nor gain, but it
+            // still keeps the whole configuration: `max_duration` governs when
+            // the integration ends, and the rest is reported back through
+            // `get_info` so it can be recorded with the observation.
+            inner.receiver_configuration = receiver_configuration;
             inner.spectrum_cancellation_token = Some(CancellationToken::new());
         } else if !receiver_configuration.integrate && inner.receiver_configuration.integrate {
             info!("Stopping integration on {}", &inner.name);
@@ -300,6 +299,7 @@ impl Telescope for FakeTelescope {
             wind_warning_ms: None,
             default_ref_freq_mhz: inner.default_ref_freq_hz / 1e6,
             default_gain_db: inner.default_gain_db,
+            receiver_configuration: inner.receiver_configuration,
         })
     }
     async fn shutdown(&self) {

--- a/src/models/observation.rs
+++ b/src/models/observation.rs
@@ -7,6 +7,7 @@ use tokio::sync::Mutex;
 
 use crate::coords::{ONSALA_LOCATION, horizontal_from_equatorial, horizontal_from_galactic};
 use crate::error::InternalError;
+use crate::models::telescope_types::ReceiverConfiguration;
 use crate::models::user::User;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -24,6 +25,15 @@ pub struct Observation {
     pub vlsr_correction_mps: Option<f64>,
     pub az_offset_deg: Option<f64>,
     pub el_offset_deg: Option<f64>,
+    /// Receiver settings the spectrum was taken with. `None` for observations
+    /// recorded before these were stored (migration V18).
+    pub gain_db: Option<f64>,
+    pub center_freq_hz: Option<f64>,
+    pub ref_freq_hz: Option<f64>,
+    pub bandwidth_hz: Option<f64>,
+    pub spectral_channels: Option<i64>,
+    pub observation_mode: Option<String>,
+    pub rfi_filter: Option<bool>,
 }
 
 impl Observation {
@@ -42,12 +52,15 @@ impl Observation {
         vlsr_correction_mps: Option<f64>,
         az_offset_deg: Option<f64>,
         el_offset_deg: Option<f64>,
+        receiver: &ReceiverConfiguration,
     ) -> Result<(), InternalError> {
         let conn = connection.lock().await;
         conn.execute(
-            "INSERT INTO observation (user_id, telescope_id, start_time, coordinate_system, target_x, target_y, integration_time_secs, frequencies_json, amplitudes_json, vlsr_correction_mps, az_offset_deg, el_offset_deg)
-                 VALUES ((?1), (?2), (?3), (?4), (?5), (?6), (?7), (?8), (?9), (?10), (?11), (?12))",
-            (
+            "INSERT INTO observation (user_id, telescope_id, start_time, coordinate_system, target_x, target_y, integration_time_secs, frequencies_json, amplitudes_json, vlsr_correction_mps, az_offset_deg, el_offset_deg, gain_db, center_freq_hz, ref_freq_hz, bandwidth_hz, spectral_channels, observation_mode, rfi_filter)
+                 VALUES ((?1), (?2), (?3), (?4), (?5), (?6), (?7), (?8), (?9), (?10), (?11), (?12), (?13), (?14), (?15), (?16), (?17), (?18), (?19))",
+            // `params!` rather than a tuple: rusqlite only implements `Params`
+            // for tuples up to 16 elements, and this is past that.
+            rusqlite::params![
                 &user.id,
                 telescope_id,
                 start_time.timestamp(),
@@ -60,7 +73,14 @@ impl Observation {
                 vlsr_correction_mps,
                 az_offset_deg,
                 el_offset_deg,
-            ),
+                receiver.gain_db,
+                receiver.center_freq_hz,
+                receiver.ref_freq_hz,
+                receiver.bandwidth_hz,
+                receiver.spectral_channels as i64,
+                format!("{:?}", receiver.mode),
+                receiver.rfi_filter,
+            ],
         )
         .map_err(|err| InternalError::new(format!("Failed to insert observation in db: {err}")))?;
         Ok(())
@@ -75,7 +95,7 @@ impl Observation {
         let conn = connection.lock().await;
         let mut stmt = conn
             .prepare(
-                "SELECT id, user_id, telescope_id, start_time, coordinate_system, target_x, target_y, integration_time_secs, frequencies_json, amplitudes_json, vlsr_correction_mps, az_offset_deg, el_offset_deg
+                "SELECT id, user_id, telescope_id, start_time, coordinate_system, target_x, target_y, integration_time_secs, frequencies_json, amplitudes_json, vlsr_correction_mps, az_offset_deg, el_offset_deg, gain_db, center_freq_hz, ref_freq_hz, bandwidth_hz, spectral_channels, observation_mode, rfi_filter
                  FROM observation
                  WHERE user_id = (?1)
                  ORDER BY start_time DESC
@@ -98,6 +118,13 @@ impl Observation {
                     vlsr_correction_mps: row.get(10)?,
                     az_offset_deg: row.get(11)?,
                     el_offset_deg: row.get(12)?,
+                    gain_db: row.get(13)?,
+                    center_freq_hz: row.get(14)?,
+                    ref_freq_hz: row.get(15)?,
+                    bandwidth_hz: row.get(16)?,
+                    spectral_channels: row.get(17)?,
+                    observation_mode: row.get(18)?,
+                    rfi_filter: row.get(19)?,
                 })
             })
             .map_err(|err| InternalError::new(format!("Failed to query_map: {err}")))?;
@@ -149,7 +176,7 @@ impl Observation {
         let conn = connection.lock().await;
         let mut stmt = conn
             .prepare(
-                "SELECT id, user_id, telescope_id, start_time, coordinate_system, target_x, target_y, integration_time_secs, frequencies_json, amplitudes_json, vlsr_correction_mps, az_offset_deg, el_offset_deg
+                "SELECT id, user_id, telescope_id, start_time, coordinate_system, target_x, target_y, integration_time_secs, frequencies_json, amplitudes_json, vlsr_correction_mps, az_offset_deg, el_offset_deg, gain_db, center_freq_hz, ref_freq_hz, bandwidth_hz, spectral_channels, observation_mode, rfi_filter
                  FROM observation
                  WHERE id = (?1) AND ((?2) IS NULL OR user_id = (?2))",
             )
@@ -170,6 +197,13 @@ impl Observation {
                     vlsr_correction_mps: row.get(10)?,
                     az_offset_deg: row.get(11)?,
                     el_offset_deg: row.get(12)?,
+                    gain_db: row.get(13)?,
+                    center_freq_hz: row.get(14)?,
+                    ref_freq_hz: row.get(15)?,
+                    bandwidth_hz: row.get(16)?,
+                    spectral_channels: row.get(17)?,
+                    observation_mode: row.get(18)?,
+                    rfi_filter: row.get(19)?,
                 })
             })
             .map_err(|err| InternalError::new(format!("Failed to query_map: {err}")))?;
@@ -239,6 +273,13 @@ mod tests {
             vlsr_correction_mps: None,
             az_offset_deg: None,
             el_offset_deg: None,
+            gain_db: None,
+            center_freq_hz: None,
+            ref_freq_hz: None,
+            bandwidth_hz: None,
+            spectral_channels: None,
+            observation_mode: None,
+            rfi_filter: None,
         }
     }
 

--- a/src/models/salsa_telescope.rs
+++ b/src/models/salsa_telescope.rs
@@ -230,7 +230,11 @@ impl Telescope for SalsaTelescope {
             }
 
             info!("Starting integration on {}", inner.name);
-            inner.receiver_configuration.integrate = true;
+            // Keep the whole configuration, not just the flag. The rest of it
+            // used to go straight to `measure()` and be forgotten, so nothing
+            // downstream — `get_info`, and through it the saved observation —
+            // could report what gain or mode a spectrum was actually taken at.
+            inner.receiver_configuration = receiver_configuration;
             inner.last_receiver_error = None;
             inner.measurements.lock().await.clear();
             let cancellation_token = CancellationToken::new();
@@ -404,6 +408,7 @@ impl Telescope for SalsaTelescope {
             wind_warning_ms: inner.wind_warning_ms,
             default_ref_freq_mhz: inner.default_ref_freq_hz / 1e6,
             default_gain_db: inner.default_gain_db,
+            receiver_configuration: inner.receiver_configuration,
         })
     }
     async fn shutdown(&self) {

--- a/src/models/telescope_types.rs
+++ b/src/models/telescope_types.rs
@@ -71,6 +71,11 @@ pub struct TelescopeInfo {
     pub wind_warning_ms: Option<f64>, // warn if 10-min avg wind exceeds this (m/s)
     pub default_ref_freq_mhz: f64,
     pub default_gain_db: f64,
+    /// What the receiver is actually set to, as opposed to the `default_*`
+    /// fields above which are only the configured starting points. Recorded
+    /// with each observation so an archived spectrum carries the gain, mode
+    /// and filter state it was taken with.
+    pub receiver_configuration: ReceiverConfiguration,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/src/routes/observations.rs
+++ b/src/routes/observations.rs
@@ -446,6 +446,31 @@ async fn get_observation_csv(
         "# Integration time: {:.0} s\n",
         observation.integration_time_secs
     ));
+    // Receiver settings, so a spectrum can be told apart from one taken at a
+    // different gain or in a different mode. Absent for observations recorded
+    // before these were stored, hence emitting each line only when present
+    // rather than writing a placeholder that could be mistaken for a value.
+    if let Some(mode) = &observation.observation_mode {
+        csv.push_str(&format!("# Observation mode: {mode}\n"));
+    }
+    if let Some(v) = observation.center_freq_hz {
+        csv.push_str(&format!("# Center frequency: {:.6} MHz\n", v / 1e6));
+    }
+    if let Some(v) = observation.ref_freq_hz {
+        csv.push_str(&format!("# Reference frequency: {:.6} MHz\n", v / 1e6));
+    }
+    if let Some(v) = observation.bandwidth_hz {
+        csv.push_str(&format!("# Bandwidth: {:.4} MHz\n", v / 1e6));
+    }
+    if let Some(v) = observation.spectral_channels {
+        csv.push_str(&format!("# Spectral channels: {v}\n"));
+    }
+    if let Some(v) = observation.gain_db {
+        csv.push_str(&format!("# Receiver gain: {v:.1} dB\n"));
+    }
+    if let Some(v) = observation.rfi_filter {
+        csv.push_str(&format!("# RFI filter: {}\n", if v { "on" } else { "off" }));
+    }
     if has_vlsr {
         csv.push_str(&format!("# VLSR correction: {:.2} m/s\n", vlsr_mps));
         csv.push_str("# Columns: frequency_hz,amplitude,vlsr_mps\n");

--- a/src/routes/observe.rs
+++ b/src/routes/observe.rs
@@ -666,6 +666,7 @@ pub(crate) async fn save_observation(
         vlsr_correction_mps,
         stored_az_offset,
         stored_el_offset,
+        &info.receiver_configuration,
     )
     .await
     {
@@ -1565,6 +1566,7 @@ mod tests {
                 wind_warning_ms: None,
                 default_ref_freq_mhz: 1417.9,
                 default_gain_db: 60.0,
+                receiver_configuration: ReceiverConfiguration::default(),
             })
         }
         async fn stop_integration(&self) -> Option<ObservedSpectra> {


### PR DESCRIPTION
Records the receiver settings each observation was taken with, so an archived spectrum can be told apart from one taken at a different gain or in a different mode.

Prompted by #317: diagnosing receiver compression on Vale depended entirely on knowing the gain, and it was recorded nowhere — the value had to be supplied from memory to interpret the data.

## Not just the export

Centre frequency and bandwidth were technically recoverable, since every channel's frequency is stored in `frequencies_json`. Gain, observation mode and RFI filter state were lost outright. Three layers needed changing:

- **`SalsaTelescope::set_receiver_configuration`** copied only `integrate` into its stored configuration and passed the rest straight to `measure()`. The running settings therefore existed nowhere once the measurement started, and `get_info` could not report them. It now keeps the whole configuration, which is what the field claimed to hold anyway. Same in `FakeTelescope`.
- **`TelescopeInfo`** gained the configuration, so the save path sees what the receiver is actually set to rather than only the configured `default_*` values.
- **The `observation` table** gained the columns (migration V18), nullable, since rows written before this have nothing to recover.

## Export

The CSV header now carries observation mode, centre and reference frequency, bandwidth, spectral channels, gain and RFI filter state. Each line is emitted only when the value is present, rather than writing a placeholder for older observations that a reader might mistake for a real setting.

```
# Integration time: 2 s
# Observation mode: Raw
# Center frequency: 1425.000000 MHz
# Reference frequency: 1417.900000 MHz
# Bandwidth: 1.0000 MHz
# Spectral channels: 8192
# Receiver gain: 42.0 dB
# RFI filter: off
```

## Verification

Against a running server, using settings deliberately different from the defaults so a stale default could not masquerade as a recorded value: gain 42 dB, 1 MHz bandwidth, 8192 channels, Raw mode, filter off. All stored correctly and all present in the export.

Backwards compatibility checked separately by inserting a row with the new columns left NULL: it still exports (settings lines simply absent) and the archive page still renders.

`cargo fmt`, `cargo clippy --all-targets --release -- -D warnings` and `cargo test --release` all clean.

Relates to #317 and #307.
